### PR TITLE
Disable Flux network policies creation

### DIFF
--- a/config/default/hmc_values.yaml
+++ b/config/default/hmc_values.yaml
@@ -8,6 +8,8 @@ cert-manager:
 
 flux2:
   enabled: true
+  policies:
+    create: false
   imageAutomationController:
     create: false
   imageReflectionController:

--- a/templates/hmc/values.yaml
+++ b/templates/hmc/values.yaml
@@ -41,6 +41,8 @@ cert-manager:
       namespace: hmc-system
 flux2:
   enabled: true
+  policies:
+    create: false
   imageAutomationController:
     create: false
   imageReflectionController:


### PR DESCRIPTION
HMC-109

Flux chart installs network policies by default. It breaks networking connectivity, so they should be disabled.