### PR TITLE
Remove additionalSecurityGroupIDs parameter for aws-standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ spec:
         cidrBlocks:
         - 10.96.0.0/12
     controlPlane:
-      additionalSecurityGroupIDs: []
       amiID: ""
       iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
       instanceType: ""
@@ -180,7 +179,6 @@ spec:
     region: ""
     sshKeyName: ""
     worker:
-      additionalSecurityGroupIDs: []
       amiID: ""
       iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
       instanceType: ""

--- a/templates/aws-standalone-cp/templates/awsmachinetemplate-controlplane.yaml
+++ b/templates/aws-standalone-cp/templates/awsmachinetemplate-controlplane.yaml
@@ -14,10 +14,6 @@ spec:
         # Makes CAPA use k0s bootstrap cloud-init directly and not via SSM
         # Simplifies the VPC setup as we do not need custom SSM endpoints etc.
         insecureSkipSecretsManager: true
-      {{- range $id := .Values.controlPlane.additionalSecurityGroupIDs }}
-      additionalSecurityGroups:
-        - id: {{ $id }}
-      {{- end }}
       {{- if not (quote .Values.sshKeyName | empty) }}
       sshKeyName: {{ .Values.sshKeyName | quote }}
       {{- end }}

--- a/templates/aws-standalone-cp/templates/awsmachinetemplate-worker.yaml
+++ b/templates/aws-standalone-cp/templates/awsmachinetemplate-worker.yaml
@@ -14,10 +14,6 @@ spec:
         # Makes CAPA use k0s bootstrap cloud-init directly and not via SSM
         # Simplifies the VPC setup as we do not need custom SSM endpoints etc.
         insecureSkipSecretsManager: true
-      {{- range $id := .Values.worker.additionalSecurityGroupIDs }}
-      additionalSecurityGroups:
-        - id: {{ $id }}
-      {{- end }}
       {{- if not (quote .Values.sshKeyName | empty) }}
       sshKeyName: {{ .Values.sshKeyName | quote }}
       {{- end }}

--- a/templates/aws-standalone-cp/values.yaml
+++ b/templates/aws-standalone-cp/values.yaml
@@ -20,13 +20,11 @@ controlPlane:
   amiID: ""
   iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
   instanceType: ""
-  additionalSecurityGroupIDs: []
 
 worker:
   amiID: ""
   iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
   instanceType: ""
-  additionalSecurityGroupIDs: []
 
 # K0s parameters
 k0s:


### PR DESCRIPTION
HMC-110

This configuration  option will only be useful if we’re using existing VPC (like in the aws-hosted-cp), but it’s not supported in the `aws-standalone-cp`, so it should be removed.