### PR TITLE
Install EBS CSI driver by default

### DIFF
--- a/templates/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -29,6 +29,8 @@ spec:
           repositories:
           - name: aws-cloud-controller-manager
             url: https://kubernetes.github.io/cloud-provider-aws
+          - name: aws-ebs-csi-driver
+            url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
           charts:
           - name: aws-cloud-controller-manager
             namespace: kube-system
@@ -44,3 +46,12 @@ spec:
               # Removing the default `node-role.kubernetes.io/control-plane` node selector
               # TODO: it does not work
               # nodeSelector: ""
+          - name: aws-ebs-csi-driver
+            namespace: kube-system
+            chartname: aws-ebs-csi-driver/aws-ebs-csi-driver
+            version: 2.33.0
+            values: |
+              defaultStorageClass:
+                enabled: true
+              node:
+                kubeletPath: /var/lib/k0s/kubelet

--- a/templates/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -30,6 +30,8 @@ spec:
             repositories:
               - name: aws-cloud-controller-manager
                 url: https://kubernetes.github.io/cloud-provider-aws
+              - name: aws-ebs-csi-driver
+                url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
             charts:
               - name: aws-cloud-controller-manager
                 namespace: kube-system
@@ -44,6 +46,15 @@ spec:
                     - --cluster-cidr={{ first .Values.clusterNetwork.pods.cidrBlocks }}
                     - --allocate-node-cidrs=true
                     - --cluster-name={{ include "cluster.name" . }}
+              - name: aws-ebs-csi-driver
+                namespace: kube-system
+                chartname: aws-ebs-csi-driver/aws-ebs-csi-driver
+                version: 2.33.0
+                values: |
+                  defaultStorageClass:
+                    enabled: true
+                  node:
+                    kubeletPath: /var/lib/k0s/kubelet
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta2


### PR DESCRIPTION
HMC-116

Currently we’re only installing CCM with our deployments. No CSI is present, so in order for user to use PVCs it should install CSI separately, which is inconvenient.