### PR TITLE
Fix Makefile's use of ARCH to rename x86_64 to amd64, fix kind-deploy/undeploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,13 +216,13 @@ endif
 .PHONY: kind-deploy
 kind-deploy: kind
 	@if ! $(KIND) get clusters | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
-		kind create cluster -n $(KIND_CLUSTER_NAME); \
+		$(KIND) create cluster -n $(KIND_CLUSTER_NAME); \
 	fi
 
 .PHONY: kind-undeploy
 kind-undeploy: kind
-	@if kind get clusters | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
-		kind delete cluster --name $(KIND_CLUSTER_NAME); \
+	@if $(KIND) get clusters | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
+		$(KIND) delete cluster --name $(KIND_CLUSTER_NAME); \
 	fi
 
 .PHONY: registry-deploy

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ os = $(shell uname|tr DL dl)
 OS := $(strip ${os})
 
 ARCH := $(shell uname -m)
+ifeq ($(ARCH),x86_64)
+	ARCH := amd64
+endif
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
'make clusterawsadm' uses the ARCH var to craft a URL for downloading the clusterawsadm binary but 'uname -m' outputs the arch as 'x86_64' while the binary versions for download use 'amd64', this modifies the arch outputted by 'uname -m' to use 'amd64' so that the curl does not fail with 'Not Found'.

# Testing
Before `make clusterawsadm`  curled a URL that does not exist and outputted a bin file with `Not Found`:

```
$ make clusterawsadm
$ curl -sL https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v2.5.2/clusterawsadm_v2.5.2_linux_x86_64 -o /home/squizzi/go/src/github.com/Mirantis/hmc/bin/clusterawsadm
chmod +x /home/squizzi/go/src/github.com/Mirantis/hmc/bin/clusterawsadm

$ curl -sL https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v2.5.2/clusterawsadm_v2.5.2_linux_x86_64    
Not Found%                                                        
```

Now, the make works as intended on `x86_64` arch systems:

```
$ make clusterawsadm 
curl -sL https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v2.5.2/clusterawsadm_v2.5.2_linux_amd64 -o /home/squizzi/go/src/github.com/Mirantis/hmc/bin/clusterawsadm
chmod +x /home/squizzi/go/src/github.com/Mirantis/hmc/bin/clusterawsadm

...

$ ./bin/clusterawsadm version  
clusterawsadm version: &version.Info{Major:"2", Minor:"5", GitVersion:"2.5.2", GitCommit:"5383d351296ff753f30c861c45275ab83069d395", GitTreeState:"clean", BuildDate:"2024-06-17T16:24:51Z", GoVersion:"go1.21.11", AwsSdkVersion:"v1.51.17", Compiler:"gc", Platform:"linux/amd64"}
