### PR TITLE
Open port 9443 (k0s join API) for all controllers

### DIFF
--- a/templates/aws-standalone-cp/templates/awscluster.yaml
+++ b/templates/aws-standalone-cp/templates/awscluster.yaml
@@ -9,3 +9,9 @@ spec:
     # name: aws-identity-name
   controlPlaneLoadBalancer:
     healthCheckProtocol: TCP
+  network:
+    additionalControlPlaneIngressRules:
+      - description: "k0s controller join API"
+        protocol: tcp
+        fromPort: 9443
+        toPort: 9443


### PR DESCRIPTION
Fixes #159 

Opened only port 9443. 
We're also missing 112 (keepalived) and 8132 (konnectivity) from [the table](https://docs.k0sproject.io/v1.30.3+k0s.0/networking/#required-ports-and-protocols), but since we're not using either of them they can be ignored