### PR TITLE
Apply Management defaults by the admission controller

### DIFF
--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -83,6 +83,14 @@ func (in *Component) HelmReleaseName() string {
 	return in.Template
 }
 
+func (m *ManagementSpec) SetDefaults() bool {
+	if m.Core != nil {
+		return false
+	}
+	m.Core = &DefaultCoreConfiguration
+	return true
+}
+
 func (m *ManagementSpec) SetProvidersDefaults() {
 	m.Providers = []Component{
 		{

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -80,8 +80,9 @@ func (r *ManagementReconciler) Update(ctx context.Context, management *hmc.Manag
 		return ctrl.Result{}, nil
 	}
 
-	// TODO: this should be implemented in admission controller instead
-	if changed := applyDefaultCoreConfiguration(management); changed {
+	// TODO: this is also implemented in admission but we have to keep it in controller as well
+	// to set defaults before the admission is started
+	if changed := management.Spec.SetDefaults(); changed {
 		l.Info("Applying default core configuration")
 		return ctrl.Result{}, r.Client.Update(ctx, management)
 	}
@@ -259,15 +260,6 @@ func (r *ManagementReconciler) enableAdmissionWebhook(ctx context.Context, mgmt 
 		Raw: updatedConfig,
 	}
 	return nil
-}
-
-func applyDefaultCoreConfiguration(mgmt *hmc.Management) (changed bool) {
-	if mgmt.Spec.Core != nil {
-		// Only apply defaults when there's no configuration provided
-		return false
-	}
-	mgmt.Spec.Core = &hmc.DefaultCoreConfiguration
-	return true
 }
 
 func updateComponentsStatus(

--- a/internal/webhook/management_webhook.go
+++ b/internal/webhook/management_webhook.go
@@ -17,7 +17,9 @@ package webhook // nolint:dupl
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,6 +75,11 @@ func (v *ManagementValidator) ValidateDelete(ctx context.Context, _ runtime.Obje
 }
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (*ManagementValidator) Default(_ context.Context, _ runtime.Object) error {
+func (*ManagementValidator) Default(_ context.Context, obj runtime.Object) error {
+	management, ok := obj.(*v1alpha1.Management)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected Management but got a %T", obj))
+	}
+	management.Spec.SetDefaults()
 	return nil
 }


### PR DESCRIPTION
Still keeping the same code in the management controller to handle the case when the admission has not started yet.

Closes #140