### PR TITLE
Specify minLength validation for deployment's template reference

### DIFF
--- a/api/v1alpha1/deployment_types.go
+++ b/api/v1alpha1/deployment_types.go
@@ -60,6 +60,7 @@ type DeploymentSpec struct {
 	DryRun bool `json:"dryRun,omitempty"`
 	// Template is a reference to a Template object located in the same namespace.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	Template string `json:"template"`
 	// Config allows to provide parameters for template customization.
 	// If no Config provided, the field will be populated with the default values for

--- a/templates/hmc/templates/crds/hmc.mirantis.com_deployments.yaml
+++ b/templates/hmc/templates/crds/hmc.mirantis.com_deployments.yaml
@@ -69,6 +69,7 @@ spec:
               template:
                 description: Template is a reference to a Template object located
                   in the same namespace.
+                minLength: 1
                 type: string
             required:
             - template


### PR DESCRIPTION
We should ensure the `spec.template` field is set and is not empty. `kubebuilder:validation:Required` marker is not enough since an empty template bypasses the validation: https://github.com/kubernetes-sigs/kubebuilder/issues/3675