### PR TITLE
Fixed HelmRelease delete

### DIFF
--- a/internal/controller/deployment_controller.go
+++ b/internal/controller/deployment_controller.go
@@ -319,6 +319,15 @@ func (r *DeploymentReconciler) Delete(ctx context.Context, l logr.Logger, deploy
 		}
 		return ctrl.Result{}, err
 	}
+	uninstall := hr.GetUninstall()
+	if !uninstall.DisableHooks {
+		uninstall.DisableHooks = true
+		hr.Spec.Uninstall = &uninstall
+		l.Info("Disabling hooks for HelmRelease")
+		if err := r.Client.Update(ctx, hr); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 	err = helm.DeleteHelmRelease(ctx, r.Client, deployment.Name, deployment.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/templates/cluster-api-provider-aws/templates/crds/awsmanagedcontrolplane.yaml
+++ b/templates/cluster-api-provider-aws/templates/crds/awsmanagedcontrolplane.yaml
@@ -353,7 +353,7 @@ spec:
                   apiServer:
                     default: false
                     description: APIServer indicates if the Kubernetes API Server log
-                      (kube-apiserver) shoulkd be enabled
+                      (kube-apiserver) should be enabled
                     type: boolean
                   audit:
                     default: false
@@ -2352,7 +2352,7 @@ spec:
                   apiServer:
                     default: false
                     description: APIServer indicates if the Kubernetes API Server log
-                      (kube-apiserver) shoulkd be enabled
+                      (kube-apiserver) should be enabled
                     type: boolean
                   audit:
                     default: false


### PR DESCRIPTION
## Description

Fixing https://github.com/Mirantis/hmc/issues/217

This fix is intended to resolve an issue when deletion of HelmRelease resulted to non-deleted (orphaned) objects.

Initially available objects for helm release:

```
k get AWScluster -n hmc-system                                                     
k get AWSMachineTemplate -n hmc-system
k get Cluster -n hmc-system
k get K0sControlPlane -n hmc-system
k get K0sWorkerConfigTemplate -n hmc-system
k get MachineDeployment -n hmc-system
```

```
NAME            CLUSTER         READY   VPC                     BASTION IP
slava-aws-dev   slava-aws-dev   true    vpc-0605fd415e9e503df  
NAME                      AGE
slava-aws-dev-cp-mt       25m
slava-aws-dev-worker-mt   25m
NAME            CLUSTERCLASS   PHASE         AGE   VERSION
slava-aws-dev                  Provisioned   25m  
NAME               AGE
slava-aws-dev-cp   25m
NAME                           AGE
slava-aws-dev-machine-config   25m
NAME               CLUSTER         REPLICAS   READY   UPDATED   UNAVAILABLE   PHASE     AGE   VERSION
slava-aws-dev-md   slava-aws-dev   1          1       1         0             Running   25m   v1.30.2
```

Several minutes after `make dev-aws-destroy`:

```
k get AWScluster -n hmc-system
k get AWSMachineTemplate -n hmc-system
k get Cluster -n hmc-system
k get K0sControlPlane -n hmc-system
k get K0sWorkerConfigTemplate -n hmc-system
k get MachineDeployment -n hmc-system
```

```
No resources found in hmc-system namespace.
No resources found in hmc-system namespace.
No resources found in hmc-system namespace.
No resources found in hmc-system namespace.
No resources found in hmc-system namespace.
No resources found in hmc-system namespace.
```

P.S. Minor misprint was fixed as well.
