### PR TITLE
Add CAPI status/conditions to deployment status

### DIFF
--- a/api/v1alpha1/deployment_types.go
+++ b/api/v1alpha1/deployment_types.go
@@ -24,6 +24,7 @@ import (
 const (
 	DeploymentFinalizer = "hmc.mirantis.com/deployment"
 
+	FluxHelmChartNameKey = "helm.toolkit.fluxcd.io/name"
 	HMCManagedLabelKey   = "hmc.mirantis.com/managed"
 	HMCManagedLabelValue = "true"
 )

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,6 +27,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -152,6 +153,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	dc, err := dynamic.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		setupLog.Error(err, "failed to create dynamic client")
+		os.Exit(1)
+	}
+
 	if err = (&controller.TemplateReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
@@ -160,9 +167,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.DeploymentReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Config: mgr.GetConfig(),
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Config:        mgr.GetConfig(),
+		DynamicClient: dc,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Deployment")
 		os.Exit(1)

--- a/internal/controller/deployment_controller_test.go
+++ b/internal/controller/deployment_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	hmc "github.com/Mirantis/hmc/api/v1alpha1"
@@ -128,6 +129,7 @@ var _ = Describe("Deployment Controller", func() {
 			controllerReconciler := &DeploymentReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
+				Config: &rest.Config{},
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{

--- a/templates/hmc/templates/rbac/roles.yaml
+++ b/templates/hmc/templates/rbac/roles.yaml
@@ -6,6 +6,13 @@ metadata:
   {{- include "hmc.labels" . | nindent 4 }}
 rules:
 - apiGroups:
+    - cluster.x-k8s.io
+  resources:
+    - clusters
+  verbs:
+    - get
+    - list
+- apiGroups:
   - helm.toolkit.fluxcd.io
   resources:
   - helmreleases


### PR DESCRIPTION
Resolves #219. This PR adds a new function that fetches the CAPI status / conditions of the cluster and places them in the deployment status/conditions. To ensure the conditions are updated the controller now requeues until the CAPI cluster conditions are all true.