### PR TITLE
Add defaultRegistryURL and defaultRepoType for non-OCI HelmRepository support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,20 +56,23 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
-	var probeAddr string
-	var secureMetrics bool
-	var enableHTTP2 bool
-	var defaultOCIRegistry string
-	var insecureRegistry bool
-	var registryCredentialsSecret string
-	var createManagement bool
-	var createTemplates bool
-	var hmcTemplatesChartName string
-	var enableTelemetry bool
-	var enableWebhook bool
-	var webhookPort int
-	var webhookCertDir string
+	var (
+		metricsAddr               string
+		probeAddr                 string
+		secureMetrics             bool
+		enableHTTP2               bool
+		defaultRegistryURL        string
+		defaultRepoType           string
+		insecureRegistry          bool
+		registryCredentialsSecret string
+		createManagement          bool
+		createTemplates           bool
+		hmcTemplatesChartName     string
+		enableTelemetry           bool
+		enableWebhook             bool
+		webhookPort               int
+		webhookCertDir            string
+	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -77,8 +80,10 @@ func main() {
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	flag.StringVar(&defaultOCIRegistry, "default-oci-registry", "oci://ghcr.io/mirantis/hmc/charts",
+	flag.StringVar(&defaultRegistryURL, "default-registry-url", "oci://ghcr.io/mirantis/hmc/charts",
 		"The default OCI registry to download Helm charts from.")
+	flag.StringVar(&defaultRepoType, "default-repo-type", "oci",
+		"The default repository type to download Helm charts from specify 'default' for http/https or 'oci' for oci.")
 	flag.StringVar(&registryCredentialsSecret, "registry-creds-secret", "",
 		"Secret containing authentication credentials for the registry.")
 	flag.BoolVar(&insecureRegistry, "insecure-registry", false, "Allow connecting to an HTTP registry.")
@@ -180,7 +185,8 @@ func main() {
 		Config:                    mgr.GetConfig(),
 		CreateManagement:          createManagement,
 		CreateTemplates:           createTemplates,
-		DefaultOCIRegistry:        defaultOCIRegistry,
+		DefaultRegistryURL:        defaultRegistryURL,
+		DefaultRepoType:           defaultRepoType,
 		RegistryCredentialsSecret: registryCredentialsSecret,
 		InsecureRegistry:          insecureRegistry,
 		HMCTemplatesChartName:     hmcTemplatesChartName,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,7 +81,7 @@ func main() {
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.StringVar(&defaultRegistryURL, "default-registry-url", "oci://ghcr.io/mirantis/hmc/charts",
-		"The default OCI registry to download Helm charts from.")
+		"The default registry to download Helm charts from.")
 	flag.StringVar(&defaultRepoType, "default-repo-type", "oci",
 		"The default repository type to download Helm charts from specify 'default' for http/https or 'oci' for oci.")
 	flag.StringVar(&registryCredentialsSecret, "registry-creds-secret", "",

--- a/config/dev/hmc_values.yaml
+++ b/config/dev/hmc_values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: hmc/controller
 controller:
-  defaultOCIRegistry: oci://hmc-local-registry:5000/charts
+  defaultRegistryURL: oci://hmc-local-registry:5000/charts
   insecureRegistry: true
   createTemplates: false

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -57,7 +57,11 @@ type Poller struct {
 	CreateManagement bool
 	CreateTemplates  bool
 
-	DefaultOCIRegistry        string
+	// DefaultRepoType is the type specified by default in HelmRepository
+	// objects.  Valid types are 'default' for http/https repositories, and
+	// 'oci' for OCI repositories.
+	DefaultRepoType           string
+	DefaultRegistryURL        string
 	RegistryCredentialsSecret string
 	InsecureRegistry          bool
 	HMCTemplatesChartName     string
@@ -183,8 +187,8 @@ func (p *Poller) reconcileDefaultHelmRepo(ctx context.Context) error {
 		}
 		helmRepo.Labels[hmc.HMCManagedLabelKey] = hmc.HMCManagedLabelValue
 		helmRepo.Spec = sourcev1.HelmRepositorySpec{
-			Type:     defaultRepoType,
-			URL:      p.DefaultOCIRegistry,
+			Type:     p.DefaultRepoType,
+			URL:      p.DefaultRegistryURL,
 			Interval: metav1.Duration{Duration: defaultReconcileInterval},
 			Insecure: p.InsecureRegistry,
 		}

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -59,7 +59,8 @@ type Poller struct {
 
 	// DefaultRepoType is the type specified by default in HelmRepository
 	// objects.  Valid types are 'default' for http/https repositories, and
-	// 'oci' for OCI repositories.
+	// 'oci' for OCI repositories.  The RepositoryType is set in main based on
+	// the URI scheme of the DefaultRegistryURL.
 	DefaultRepoType           string
 	DefaultRegistryURL        string
 	RegistryCredentialsSecret string
@@ -185,6 +186,7 @@ func (p *Poller) reconcileDefaultHelmRepo(ctx context.Context) error {
 		if helmRepo.Labels == nil {
 			helmRepo.Labels = make(map[string]string)
 		}
+
 		helmRepo.Labels[hmc.HMCManagedLabelKey] = hmc.HMCManagedLabelValue
 		helmRepo.Spec = sourcev1.HelmRepositorySpec{
 			Type:     p.DefaultRepoType,

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -39,9 +39,7 @@ import (
 )
 
 const (
-	defaultRepoName = "hmc-templates"
-	defaultRepoType = "oci"
-
+	defaultRepoName          = "hmc-templates"
 	defaultReconcileInterval = 10 * time.Minute
 )
 

--- a/internal/utils/helm.go
+++ b/internal/utils/helm.go
@@ -1,0 +1,41 @@
+// Copyright 2024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"net/url"
+)
+
+const (
+	registryTypeOCI     = "oci"
+	registryTypeDefault = "default"
+)
+
+func DetermineDefaultRepositoryType(defaultRegistryURL string) (string, error) {
+	parsedRegistryURL, err := url.Parse(defaultRegistryURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse default registry URL: %w", err)
+	}
+
+	switch parsedRegistryURL.Scheme {
+	case "oci":
+		return registryTypeOCI, nil
+	case "http", "https":
+		return registryTypeDefault, nil
+	default:
+		return "", fmt.Errorf("invalid default registry URL scheme: %s must be 'oci://', 'http://', or 'https://'", parsedRegistryURL.Scheme)
+	}
+}

--- a/internal/utils/helm_test.go
+++ b/internal/utils/helm_test.go
@@ -1,0 +1,47 @@
+// Copyright 2024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestDetermineDefaultRepositoryType(t *testing.T) {
+	for _, tc := range []struct {
+		url            string
+		expectErr      bool
+		expectedScheme string
+	}{
+		{url: "oci://hmc-local-registry:5000/charts", expectErr: false, expectedScheme: "oci"},
+		{url: "https://registry.example.com", expectErr: false, expectedScheme: "default"},
+		{url: "http://docker.io", expectErr: false, expectedScheme: "default"},
+		{url: "ftp://ftp.example.com", expectErr: true},
+		{url: "not-a-url", expectErr: true},
+	} {
+		t.Run(tc.url, func(t *testing.T) {
+			actual, err := DetermineDefaultRepositoryType(tc.url)
+			if tc.expectErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+
+				if actual != tc.expectedScheme {
+					t.Errorf("expected scheme %q, got %q", tc.expectedScheme, actual)
+				}
+			}
+		})
+	}
+}

--- a/templates/hmc/templates/deployment.yaml
+++ b/templates/hmc/templates/deployment.yaml
@@ -21,7 +21,8 @@ spec:
     spec:
       containers:
       - args:
-        - --default-oci-registry={{ .Values.controller.defaultOCIRegistry }}
+        - --default-registry-url={{ .Values.controller.defaultRegistryURL }}
+        - --default-repo-type={{ .Values.controller.defaultRepoType}}
         - --insecure-registry={{ .Values.controller.insecureRegistry }}
         {{- if .Values.controller.registryCredsSecret }}
         - --registry-creds-secret={{ .Values.controller.registryCredsSecret }}

--- a/templates/hmc/templates/deployment.yaml
+++ b/templates/hmc/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
       containers:
       - args:
         - --default-registry-url={{ .Values.controller.defaultRegistryURL }}
-        - --default-repo-type={{ .Values.controller.defaultRepoType}}
         - --insecure-registry={{ .Values.controller.insecureRegistry }}
         {{- if .Values.controller.registryCredsSecret }}
         - --registry-creds-secret={{ .Values.controller.registryCredsSecret }}

--- a/templates/hmc/values.yaml
+++ b/templates/hmc/values.yaml
@@ -7,7 +7,8 @@ admissionWebhook:
   certDir: "/tmp/k8s-webhook-server/serving-certs/"
 
 controller:
-  defaultOCIRegistry: "oci://ghcr.io/mirantis/hmc/charts"
+  defaultRegistryURL: "oci://ghcr.io/mirantis/hmc/charts"
+  defaultRepoType: "oci"
   registryCredsSecret: ""
   insecureRegistry: false
   createManagement: true


### PR DESCRIPTION
While working on figuring out what registry to use for CI in #220  I thought why not use Mirantis Secure Registry (MSR)?welp.. that was a journey.

Currently we hardcode the `HelmRepostory` type to `oci` when reconciling the default `hmc-templates` repository.  The problem with this is, for whatever reason, MSR does not like OCI (even though, I'm pretty sure it implements the spec) and it results in `insufficient_scope` errors when we try to pull the charts.  After some digging through `helm-controller` CRDs and docs I discovered this setting: https://fluxcd.io/flux/components/source/helmrepositories/#type and changed our `HelmRepository` we reconcile to use `'default'` which fixed the issue and pulled the chart with no problems.

---

This patch renames the existing 'defaultOCIRegistry' flag and associated Helm values to 'defaultRegistryURL' and introduces a new type: 'defaultRepoType' which allows for modification of the previously hardcoded 'oci' type for chart repositories.