### PR TITLE
Improve ManagedCluster validation

### DIFF
--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -86,6 +86,13 @@ func (m *ManagementSpec) SetProvidersDefaults() error {
 	return nil
 }
 
+func (m *ManagementSpec) GetCoreTemplates() map[string]bool {
+	return map[string]bool{
+		m.Core.HMC.Template:  true,
+		m.Core.CAPI.Template: true,
+	}
+}
+
 // ManagementStatus defines the observed state of Management
 type ManagementStatus struct {
 	// ObservedGeneration is the last observed generation.

--- a/internal/webhook/managedcluster_webhook_test.go
+++ b/internal/webhook/managedcluster_webhook_test.go
@@ -31,33 +31,56 @@ import (
 	"github.com/Mirantis/hmc/test/scheme"
 )
 
+type testCase struct {
+	name              string
+	oldManagedCluster *v1alpha1.ManagedCluster
+	newManagedCluster *v1alpha1.ManagedCluster
+	existingObjects   []runtime.Object
+	err               string
+	warnings          admission.Warnings
+}
+
+const (
+	testNamespace = "test"
+
+	testTemplateName      = "template-test"
+	templateUpgradeSource = "template-1-0-0"
+
+	hmcTemplateName  = "hmc"
+	capiTemplateName = "cluster-api"
+	capzTemplateName = "cluster-api-provider-azure"
+)
+
 var (
-	testTemplateName = "template-test"
-	testNamespace    = "test"
+	coreConfiguration = v1alpha1.Core{
+		HMC:  v1alpha1.Component{Template: hmcTemplateName},
+		CAPI: v1alpha1.Component{Template: capiTemplateName},
+	}
 
 	mgmt = management.NewManagement(
+		management.WithCoreComponents(&coreConfiguration),
 		management.WithAvailableProviders(v1alpha1.Providers{
 			InfrastructureProviders: []string{"aws"},
 			BootstrapProviders:      []string{"k0s"},
 			ControlPlaneProviders:   []string{"k0s"},
 		}),
+		management.WithComponentsStatus(map[string]v1alpha1.ComponentStatus{
+			hmcTemplateName:  {Success: true},
+			capiTemplateName: {Success: true},
+		}),
 	)
 
-	createAndUpdateTests = []struct {
-		name            string
-		managedCluster  *v1alpha1.ManagedCluster
-		existingObjects []runtime.Object
-		err             string
-		warnings        admission.Warnings
-	}{
+	createAndUpdateTests = []testCase{
 		{
-			name:           "should fail if the template is unset",
-			managedCluster: managedcluster.NewManagedCluster(),
-			err:            "the ManagedCluster is invalid: clustertemplates.hmc.mirantis.com \"\" not found",
+			name:              "should fail if the template is unset",
+			oldManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(templateUpgradeSource)),
+			newManagedCluster: managedcluster.NewManagedCluster(),
+			err:               "the ManagedCluster is invalid: clustertemplates.hmc.mirantis.com \"\" not found",
 		},
 		{
-			name:           "should fail if the ClusterTemplate is not found in the ManagedCluster's namespace",
-			managedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(testTemplateName)),
+			name:              "should fail if the ClusterTemplate is not found in the ManagedCluster's namespace",
+			oldManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(templateUpgradeSource)),
+			newManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(testTemplateName)),
 			existingObjects: []runtime.Object{
 				mgmt,
 				template.NewClusterTemplate(
@@ -68,8 +91,9 @@ var (
 			err: fmt.Sprintf("the ManagedCluster is invalid: clustertemplates.hmc.mirantis.com \"%s\" not found", testTemplateName),
 		},
 		{
-			name:           "should fail if the cluster template was found but is invalid (some validation error)",
-			managedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(testTemplateName)),
+			name:              "should fail if the cluster template was found but is invalid (some validation error)",
+			oldManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(templateUpgradeSource)),
+			newManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(testTemplateName)),
 			existingObjects: []runtime.Object{
 				mgmt,
 				template.NewClusterTemplate(
@@ -83,30 +107,9 @@ var (
 			err: "the ManagedCluster is invalid: the template is not valid: validation error example",
 		},
 		{
-			name:           "should fail if one or more requested providers are not available yet",
-			managedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(testTemplateName)),
-			existingObjects: []runtime.Object{
-				management.NewManagement(
-					management.WithAvailableProviders(v1alpha1.Providers{
-						InfrastructureProviders: []string{"aws"},
-						BootstrapProviders:      []string{"k0s"},
-					}),
-				),
-				template.NewClusterTemplate(
-					template.WithName(testTemplateName),
-					template.WithProvidersStatus(v1alpha1.Providers{
-						InfrastructureProviders: []string{"azure"},
-						BootstrapProviders:      []string{"k0s"},
-						ControlPlaneProviders:   []string{"k0s"},
-					}),
-					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
-				),
-			},
-			err: "the ManagedCluster is invalid: providers verification failed: one or more required control plane providers are not deployed yet: [k0s]\none or more required infrastructure providers are not deployed yet: [azure]",
-		},
-		{
-			name:           "should succeed",
-			managedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(testTemplateName)),
+			name:              "should succeed",
+			oldManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(templateUpgradeSource)),
+			newManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(testTemplateName)),
 			existingObjects: []runtime.Object{
 				mgmt,
 				template.NewClusterTemplate(
@@ -127,11 +130,124 @@ func TestManagedClusterValidateCreate(t *testing.T) {
 	g := NewWithT(t)
 
 	ctx := context.Background()
-	for _, tt := range createAndUpdateTests {
+
+	tests := createAndUpdateTests
+	tests = append(tests, []testCase{
+		{
+			name:              "should fail if one or more requested providers are not available yet",
+			oldManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(templateUpgradeSource)),
+			newManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(testTemplateName)),
+			existingObjects: []runtime.Object{
+				management.NewManagement(
+					management.WithCoreComponents(&coreConfiguration),
+					management.WithAvailableProviders(v1alpha1.Providers{
+						InfrastructureProviders: []string{"aws"},
+						BootstrapProviders:      []string{"k0s"},
+					}),
+					management.WithComponentsStatus(map[string]v1alpha1.ComponentStatus{
+						hmcTemplateName:  {Success: true},
+						capiTemplateName: {Success: true},
+					}),
+				),
+				template.NewClusterTemplate(
+					template.WithName(testTemplateName),
+					template.WithProvidersStatus(v1alpha1.Providers{
+						InfrastructureProviders: []string{"azure"},
+						BootstrapProviders:      []string{"k0s"},
+						ControlPlaneProviders:   []string{"k0s"},
+					}),
+					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
+				),
+			},
+			warnings: admission.Warnings{
+				"not ready control plane providers: [k0s]",
+				"not ready infrastructure providers: [azure]",
+			},
+			err: "one or more required components are not ready",
+		},
+		{
+			name:              "should fail if one or more providers and core components are not ready yet",
+			newManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(testTemplateName)),
+			existingObjects: []runtime.Object{
+				management.NewManagement(
+					management.WithCoreComponents(&coreConfiguration),
+					management.WithAvailableProviders(v1alpha1.Providers{
+						InfrastructureProviders: []string{"aws"},
+						BootstrapProviders:      []string{"k0s"},
+					}),
+					management.WithComponentsStatus(map[string]v1alpha1.ComponentStatus{
+						hmcTemplateName: {Success: true},
+						capiTemplateName: {
+							Success: false,
+							Error:   "cluster-api template is invalid",
+						},
+					}),
+				),
+				template.NewProviderTemplate(template.WithName(hmcTemplateName)),
+				template.NewProviderTemplate(
+					template.WithName(capiTemplateName),
+					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: false}),
+				),
+				template.NewClusterTemplate(
+					template.WithName(testTemplateName),
+					template.WithProvidersStatus(v1alpha1.Providers{
+						InfrastructureProviders: []string{"azure"},
+						BootstrapProviders:      []string{"k0s"},
+						ControlPlaneProviders:   []string{"k0s"},
+					}),
+					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
+				),
+			},
+			warnings: admission.Warnings{
+				"not ready control plane providers: [k0s]",
+				"not ready core components: [cluster-api]",
+				"not ready infrastructure providers: [azure]",
+				"cluster-api installation failed: cluster-api template is invalid",
+			},
+			err: "one or more required components are not ready",
+		},
+		{
+			name:              "should succeed if one or more providers failed but it is not required",
+			newManagedCluster: managedcluster.NewManagedCluster(managedcluster.WithTemplate(testTemplateName)),
+			existingObjects: []runtime.Object{
+				management.NewManagement(
+					management.WithCoreComponents(&coreConfiguration),
+					management.WithAvailableProviders(v1alpha1.Providers{
+						InfrastructureProviders: []string{"aws", "azure"},
+						BootstrapProviders:      []string{"k0s"},
+						ControlPlaneProviders:   []string{"k0s"},
+					}),
+					management.WithComponentsStatus(map[string]v1alpha1.ComponentStatus{
+						hmcTemplateName:  {Success: true},
+						capiTemplateName: {Success: true},
+						capzTemplateName: {
+							Success: false,
+							Error:   "cluster API provider Azure deployment failed",
+						},
+					}),
+				),
+				template.NewProviderTemplate(
+					template.WithName(capzTemplateName),
+					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: false}),
+				),
+				template.NewClusterTemplate(
+					template.WithName(testTemplateName),
+					template.WithProvidersStatus(v1alpha1.Providers{
+						InfrastructureProviders: []string{"aws"},
+						BootstrapProviders:      []string{"k0s"},
+						ControlPlaneProviders:   []string{"k0s"},
+					}),
+					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
+				),
+			},
+		},
+	}...)
+
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.existingObjects...).Build()
 			validator := &ManagedClusterValidator{Client: c}
-			warn, err := validator.ValidateCreate(ctx, tt.managedCluster)
+			warn, err := validator.ValidateCreate(ctx, tt.newManagedCluster)
 			if tt.err != "" {
 				g.Expect(err).To(HaveOccurred())
 				if err.Error() != tt.err {
@@ -157,7 +273,7 @@ func TestManagedClusterValidateUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.existingObjects...).Build()
 			validator := &ManagedClusterValidator{Client: c}
-			warn, err := validator.ValidateUpdate(ctx, managedcluster.NewManagedCluster(), tt.managedCluster)
+			warn, err := validator.ValidateUpdate(ctx, tt.oldManagedCluster, tt.newManagedCluster)
 			if tt.err != "" {
 				g.Expect(err).To(HaveOccurred())
 				if err.Error() != tt.err {

--- a/test/objects/template/template.go
+++ b/test/objects/template/template.go
@@ -55,9 +55,11 @@ func NewServiceTemplate(opts ...Opt) *v1alpha1.ServiceTemplate {
 func NewProviderTemplate(opts ...Opt) *v1alpha1.ProviderTemplate {
 	templateState := NewTemplate(opts...)
 	return &v1alpha1.ProviderTemplate{
-		ObjectMeta: templateState.ObjectMeta,
-		Spec:       v1alpha1.ProviderTemplateSpec{TemplateSpecCommon: templateState.Spec},
-		Status:     v1alpha1.ProviderTemplateStatus{TemplateStatusCommon: templateState.Status},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: templateState.Name,
+		},
+		Spec:   v1alpha1.ProviderTemplateSpec{TemplateSpecCommon: templateState.Spec},
+		Status: v1alpha1.ProviderTemplateStatus{TemplateStatusCommon: templateState.Status},
 	}
 }
 


### PR DESCRIPTION
Closes #236 #249

This PR introduces the following changes:
1. Verify core components' and required providers' readiness on ManagedCluster creation according to the Management object status
3. Adapt testing cases accordingly