### PR TITLE
Fix erroneous `errors.Join` usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	github.com/opencontainers/go-digest v1.0.1-0.20231025023718-d50d2fec9c98
-	github.com/pkg/errors v0.9.1
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	helm.sh/helm/v3 v3.15.4
 	k8s.io/api v0.31.0
@@ -115,6 +114,7 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc6 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -17,13 +17,13 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	hcv2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/storage/driver"

--- a/internal/utils/kube.go
+++ b/internal/utils/kube.go
@@ -35,11 +35,11 @@ func EnsureDeleteAllOf(ctx context.Context, cl client.Client, gvk schema.GroupVe
 	for _, item := range itemsList.Items {
 		if item.DeletionTimestamp.IsZero() {
 			if err := cl.Delete(ctx, &item); err != nil && !apierrors.IsNotFound(err) {
-				errs = errors.Join(err)
+				errs = errors.Join(errs, err)
 				continue
 			}
 		}
-		errs = errors.Join(fmt.Errorf("waiting for %s %s/%s removal", gvk.Kind, item.Namespace, item.Name))
+		errs = errors.Join(errs, fmt.Errorf("waiting for %s %s/%s removal", gvk.Kind, item.Namespace, item.Name))
 	}
 	return errs
 }

--- a/internal/webhook/deployment_webhook.go
+++ b/internal/webhook/deployment_webhook.go
@@ -37,9 +37,7 @@ type DeploymentValidator struct {
 	client.Client
 }
 
-var (
-	InvalidDeploymentErr = errors.New("the deployment is invalid")
-)
+var InvalidDeploymentErr = errors.New("the deployment is invalid")
 
 func (v *DeploymentValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	v.Client = mgr.GetClient()


### PR DESCRIPTION
* properly leverage multierr feature via `errors.Join`
* side: removed undesired package from the direct dependencies

Fixes #258