### PR TITLE
update dev examples from `Deployment` to `ManagedCluster`

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -23,7 +23,7 @@ resources:
   controller: true
   domain: hmc.mirantis.com
   group: hmc.mirantis.com
-  kind: Deployment
+  kind: ManagedCluster
   path: github.com/Mirantis/hmc/api/v1alpha1
   version: v1alpha1
 - api:

--- a/config/dev/aws-managedcluster.yaml
+++ b/config/dev/aws-managedcluster.yaml
@@ -1,5 +1,5 @@
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: Deployment
+kind: ManagedCluster
 metadata:
   name: aws-dev
   namespace: ${NAMESPACE}

--- a/config/dev/azure-managedcluster.yaml
+++ b/config/dev/azure-managedcluster.yaml
@@ -1,5 +1,5 @@
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: Deployment
+kind: ManagedCluster
 metadata:
   name: azure-dev
   namespace: ${NAMESPACE}


### PR DESCRIPTION
In https://github.com/Mirantis/hmc/pull/265 we changed the code from `Deployment` to `ManagedCluster`, this also updates the examples