### PR TITLE
Add support for testing `aws-hosted-cp`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,25 +21,64 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'test-e2e')
-    env:
-      AWS_REGION: us-west-2
-      AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-        go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get outputs
+        id: vars
+        run: |
+          echo "version=$(git describe --tags --always)" >> $GITHUB_OUTPUT
+
+      - name: Build and push HMC controller image
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            LD_FLAGS=-s -w -X github.com/Mirantis/hmc/internal/build.Version=${{ steps.vars.outputs.version }}
+          context: .
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/mirantis/hmc/controller-ci:${{ steps.vars.outputs.version }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Prepare and push HMC template charts
+        run: |
+          make hmc-chart-release
+          REGISTRY_REPO="oci://ghcr.io/mirantis/hmc/charts-ci" make helm-push
+
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
+
       - name: Run E2E tests
+        env:
+          REGISTRY_REPO: 'ghcr.io/mirantis/hmc/charts-ci'
+          IMG: 'ghcr.io/mirantis/hmc/controller-ci:${{ steps.vars.outputs.version }}'
+          AWS_REGION: us-west-2
+          AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
         run: |
           make test-e2e
+
       - name: Archive test results
         uses: actions/upload-artifact@v4
         with:
-        name: test-logs
-        path: |
-          test/e2e/*.log
+          name: test-logs
+          path: |
+            test/e2e/*.log

--- a/config/dev/aws-managedcluster.yaml
+++ b/config/dev/aws-managedcluster.yaml
@@ -1,16 +1,17 @@
 apiVersion: hmc.mirantis.com/v1alpha1
 kind: ManagedCluster
 metadata:
-  name: aws-dev
+  name: squizz-aws-dev
   namespace: ${NAMESPACE}
 spec:
   config:
     controlPlane:
-      instanceType: t3.small
+      instanceType: t3.xlarge
     controlPlaneNumber: 1
     publicIP: true
     region: us-west-2
     worker:
-      instanceType: t3.small
+      instanceType: t3.xlarge
     workersNumber: 1
+    installBeachHeadServices: false
   template: aws-standalone-cp

--- a/config/dev/hmc_values.yaml
+++ b/config/dev/hmc_values.yaml
@@ -1,5 +1,6 @@
 image:
   repository: hmc/controller
+  tag: latest
 controller:
   defaultOCIRegistry: oci://hmc-local-registry:5000/charts
   insecureRegistry: true

--- a/test/kubeclient/kubeclient.go
+++ b/test/kubeclient/kubeclient.go
@@ -16,14 +16,11 @@ package kubeclient
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
-	"github.com/Mirantis/hmc/test/utils"
 	. "github.com/onsi/ginkgo/v2"
-	corev1 "k8s.io/api/core/v1"
+	. "github.com/onsi/gomega"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,10 +30,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-)
-
-const (
-	awsCredentialsSecretName = "aws-variables"
 )
 
 type KubeClient struct {
@@ -49,145 +42,122 @@ type KubeClient struct {
 
 // NewFromLocal creates a new instance of KubeClient from a given namespace
 // using the locally found kubeconfig.
-func NewFromLocal(namespace string) (*KubeClient, error) {
-	configBytes, err := getLocalKubeConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get local kubeconfig: %w", err)
-	}
-
-	return new(configBytes, namespace)
+func NewFromLocal(namespace string) *KubeClient {
+	GinkgoHelper()
+	return new(getLocalKubeConfig(), namespace)
 }
 
 // NewFromCluster creates a new KubeClient using the kubeconfig stored in the
 // secret affiliated with the given clusterName.  Since it relies on fetching
 // the kubeconfig from secret it needs an existing kubeclient.
-func (kc *KubeClient) NewFromCluster(ctx context.Context, namespace, clusterName string) (*KubeClient, error) {
-	secret, err := kc.Client.CoreV1().Secrets(kc.Namespace).Get(ctx, clusterName+"-kubeconfig", metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cluster: %q kubeconfig secret: %w", clusterName, err)
+func (kc *KubeClient) NewFromCluster(ctx context.Context, namespace, clusterName string) *KubeClient {
+	GinkgoHelper()
+	return new(kc.getKubeconfigSecretData(ctx, clusterName), namespace)
+}
+
+// WriteKubeconfig writes the kubeconfig for the given clusterName to the
+// test/e2e directory returning the path to the file and a function to delete
+// it later.
+func (kc *KubeClient) WriteKubeconfig(ctx context.Context, clusterName string) (string, func() error) {
+	GinkgoHelper()
+
+	secretData := kc.getKubeconfigSecretData(ctx, clusterName)
+
+	path := clusterName + "-kubeconfig"
+
+	Expect(
+		os.WriteFile(filepath.Join("../e2e", path), secretData, 0644)).
+		To(Succeed())
+
+	deleteFunc := func() error {
+		return os.Remove(filepath.Join("../e2e", path))
 	}
+
+	return path, deleteFunc
+}
+
+func (kc *KubeClient) getKubeconfigSecretData(ctx context.Context, clusterName string) []byte {
+	GinkgoHelper()
+
+	secret, err := kc.Client.CoreV1().Secrets(kc.Namespace).Get(ctx, clusterName+"-kubeconfig", metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to get cluster: %q kubeconfig secret", clusterName)
 
 	secretData, ok := secret.Data["value"]
-	if !ok {
-		return nil, fmt.Errorf("kubeconfig secret %q has no 'value' key", clusterName)
-	}
+	Expect(ok).To(BeTrue(), "kubeconfig secret %q has no 'value' key", clusterName)
 
-	return new(secretData, namespace)
+	return secretData
 }
 
 // getLocalKubeConfig returns the kubeconfig file content.
-func getLocalKubeConfig() ([]byte, error) {
+func getLocalKubeConfig() []byte {
+	GinkgoHelper()
+
 	// Use the KUBECONFIG environment variable if it is set, otherwise use the
 	// default path.
 	kubeConfig, ok := os.LookupEnv("KUBECONFIG")
 	if !ok {
 		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get user home directory: %w", err)
-		}
+		Expect(err).NotTo(HaveOccurred(), "failed to get user home directory")
 
 		kubeConfig = filepath.Join(homeDir, ".kube", "config")
 	}
 
 	configBytes, err := os.ReadFile(kubeConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read %q: %w", kubeConfig, err)
-	}
+	Expect(err).NotTo(HaveOccurred(), "failed to read %q", kubeConfig)
 
-	return configBytes, nil
+	return configBytes
 }
 
 // new creates a new instance of KubeClient from a given namespace using
 // the local kubeconfig.
-func new(configBytes []byte, namespace string) (*KubeClient, error) {
+func new(configBytes []byte, namespace string) *KubeClient {
+	GinkgoHelper()
+
 	config, err := clientcmd.RESTConfigFromKubeConfig(configBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
-	}
+	Expect(err).NotTo(HaveOccurred(), "failed to parse kubeconfig")
 
 	clientSet, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("could not initialize kubernetes client: %w", err)
-	}
+	Expect(err).NotTo(HaveOccurred(), "failed to initialize kubernetes client")
 
 	extendedClientSet, err := apiextensionsclientset.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize apiextensions clientset: %w", err)
-	}
+	Expect(err).NotTo(HaveOccurred(), "failed to initialize apiextensions clientset")
 
 	return &KubeClient{
 		Namespace:      namespace,
 		Client:         clientSet,
 		ExtendedClient: extendedClientSet,
 		Config:         config,
-	}, nil
-}
-
-// CreateAWSCredentialsKubeSecret uses clusterawsadm to encode existing AWS
-// credentials and create a secret in the given namespace if one does not
-// already exist.
-func (kc *KubeClient) CreateAWSCredentialsKubeSecret(ctx context.Context) error {
-	_, err := kc.Client.CoreV1().Secrets(kc.Namespace).Get(ctx, awsCredentialsSecretName, metav1.GetOptions{})
-	if !apierrors.IsNotFound(err) {
-		return nil
 	}
-
-	cmd := exec.Command("./bin/clusterawsadm", "bootstrap", "credentials", "encode-as-profile")
-	output, err := utils.Run(cmd)
-	if err != nil {
-		return fmt.Errorf("failed to encode AWS credentials with clusterawsadm: %w", err)
-	}
-
-	_, err = kc.Client.CoreV1().Secrets(kc.Namespace).Create(ctx, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: awsCredentialsSecretName,
-		},
-		Data: map[string][]byte{
-			"AWS_B64ENCODED_CREDENTIALS": output,
-		},
-		Type: corev1.SecretTypeOpaque,
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create AWS credentials secret: %w", err)
-	}
-
-	return nil
 }
 
 // GetDynamicClient returns a dynamic client for the given GroupVersionResource.
-func (kc *KubeClient) GetDynamicClient(gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error) {
-	client, err := dynamic.NewForConfig(kc.Config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
-	}
+func (kc *KubeClient) GetDynamicClient(gvr schema.GroupVersionResource) dynamic.ResourceInterface {
+	GinkgoHelper()
 
-	return client.Resource(gvr).Namespace(kc.Namespace), nil
+	client, err := dynamic.NewForConfig(kc.Config)
+	Expect(err).NotTo(HaveOccurred(), "failed to create dynamic client")
+
+	return client.Resource(gvr).Namespace(kc.Namespace)
 }
 
-// CreateDeployment creates a managedcluster.hmc.mirantis.com in the given
+// CreateManagedCluster creates a managedcluster.hmc.mirantis.com in the given
 // namespace and returns a DeleteFunc to clean up the deployment.
 // The DeleteFunc is a no-op if the deployment has already been deleted.
 func (kc *KubeClient) CreateManagedCluster(
-	ctx context.Context, managedcluster *unstructured.Unstructured) (func() error, error) {
+	ctx context.Context, managedcluster *unstructured.Unstructured) func() error {
+	GinkgoHelper()
+
 	kind := managedcluster.GetKind()
+	Expect(kind).To(Equal("ManagedCluster"))
 
-	if kind != "ManagedCluster" {
-		return nil, fmt.Errorf("expected kind ManagedCluster, got: %s", kind)
-	}
-
-	client, err := kc.GetDynamicClient(schema.GroupVersionResource{
+	client := kc.GetDynamicClient(schema.GroupVersionResource{
 		Group:    "hmc.mirantis.com",
 		Version:  "v1alpha1",
 		Resource: "managedclusters",
 	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get dynamic client: %w", err)
-	}
 
-	_, err = client.Create(ctx, managedcluster, metav1.CreateOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Deployment: %w", err)
-	}
+	_, err := client.Create(ctx, managedcluster, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to create %s", kind)
 
 	return func() error {
 		err := client.Delete(ctx, managedcluster.GetName(), metav1.DeleteOptions{})
@@ -195,51 +165,47 @@ func (kc *KubeClient) CreateManagedCluster(
 			return nil
 		}
 		return err
-	}, nil
+	}
 }
 
 // GetCluster returns a Cluster resource by name.
-func (kc *KubeClient) GetCluster(ctx context.Context, clusterName string) (*unstructured.Unstructured, error) {
+func (kc *KubeClient) GetCluster(ctx context.Context, clusterName string) *unstructured.Unstructured {
+	GinkgoHelper()
+
 	gvr := schema.GroupVersionResource{
 		Group:    "cluster.x-k8s.io",
 		Version:  "v1beta1",
 		Resource: "clusters",
 	}
 
-	client, err := kc.GetDynamicClient(gvr)
-	if err != nil {
-		Fail(fmt.Sprintf("failed to get %s client: %v", gvr.Resource, err))
-	}
+	client := kc.GetDynamicClient(gvr)
 
 	cluster, err := client.Get(ctx, clusterName, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get %s %s: %w", gvr.Resource, clusterName, err)
-	}
+	Expect(err).NotTo(HaveOccurred(), "failed to get %s %s", gvr.Resource, clusterName)
 
-	return cluster, nil
+	return cluster
 }
 
 // listResource returns a list of resources for the given GroupVersionResource
 // affiliated with the given clusterName.
 func (kc *KubeClient) listResource(
-	ctx context.Context, gvr schema.GroupVersionResource, clusterName string) ([]unstructured.Unstructured, error) {
-	client, err := kc.GetDynamicClient(gvr)
-	if err != nil {
-		Fail(fmt.Sprintf("failed to get %s client: %v", gvr.Resource, err))
-	}
+	ctx context.Context, gvr schema.GroupVersionResource, clusterName string) []unstructured.Unstructured {
+	GinkgoHelper()
+
+	client := kc.GetDynamicClient(gvr)
 
 	resources, err := client.List(ctx, metav1.ListOptions{
 		LabelSelector: "cluster.x-k8s.io/cluster-name=" + clusterName,
 	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list %s: %w", gvr.Resource, err)
-	}
+	Expect(err).NotTo(HaveOccurred(), "failed to list %s", gvr.Resource)
 
-	return resources.Items, nil
+	return resources.Items
 }
 
 // ListMachines returns a list of Machine resources for the given cluster.
-func (kc *KubeClient) ListMachines(ctx context.Context, clusterName string) ([]unstructured.Unstructured, error) {
+func (kc *KubeClient) ListMachines(ctx context.Context, clusterName string) []unstructured.Unstructured {
+	GinkgoHelper()
+
 	return kc.listResource(ctx, schema.GroupVersionResource{
 		Group:    "cluster.x-k8s.io",
 		Version:  "v1beta1",
@@ -250,7 +216,9 @@ func (kc *KubeClient) ListMachines(ctx context.Context, clusterName string) ([]u
 // ListMachineDeployments returns a list of MachineDeployment resources for the
 // given cluster.
 func (kc *KubeClient) ListMachineDeployments(
-	ctx context.Context, clusterName string) ([]unstructured.Unstructured, error) {
+	ctx context.Context, clusterName string) []unstructured.Unstructured {
+	GinkgoHelper()
+
 	return kc.listResource(ctx, schema.GroupVersionResource{
 		Group:    "cluster.x-k8s.io",
 		Version:  "v1beta1",
@@ -259,7 +227,9 @@ func (kc *KubeClient) ListMachineDeployments(
 }
 
 func (kc *KubeClient) ListK0sControlPlanes(
-	ctx context.Context, clusterName string) ([]unstructured.Unstructured, error) {
+	ctx context.Context, clusterName string) []unstructured.Unstructured {
+	GinkgoHelper()
+
 	return kc.listResource(ctx, schema.GroupVersionResource{
 		Group:    "controlplane.cluster.x-k8s.io",
 		Version:  "v1beta1",

--- a/test/managedcluster/aws/aws.go
+++ b/test/managedcluster/aws/aws.go
@@ -1,0 +1,123 @@
+// Copyright 2024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains specific helpers for testing a managed cluster
+// that uses the AWS infrastructure provider.
+package aws
+
+import (
+	"context"
+	"os"
+	"os/exec"
+
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/Mirantis/hmc/test/kubeclient"
+	"github.com/Mirantis/hmc/test/managedcluster"
+	"github.com/Mirantis/hmc/test/utils"
+)
+
+// CreateCredentialSecret uses clusterawsadm to encode existing AWS
+// credentials and create a secret in the given namespace if one does not
+// already exist.
+func CreateCredentialSecret(ctx context.Context, kc *kubeclient.KubeClient) {
+	GinkgoHelper()
+
+	_, err := kc.Client.CoreV1().Secrets(kc.Namespace).
+		Get(ctx, managedcluster.AWSCredentialsSecretName, metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred(), "failed to get AWS credentials secret")
+		return
+	}
+
+	cmd := exec.Command("./bin/clusterawsadm", "bootstrap", "credentials", "encode-as-profile")
+	output, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "failed to encode AWS credentials with clusterawsadm")
+
+	_, err = kc.Client.CoreV1().Secrets(kc.Namespace).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: managedcluster.AWSCredentialsSecretName,
+		},
+		Data: map[string][]byte{
+			"AWS_B64ENCODED_CREDENTIALS": output,
+		},
+		Type: corev1.SecretTypeOpaque,
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to create AWS credentials secret")
+}
+
+// PopulateHostedTemplateVars populates the environment variables required for
+// the AWS hosted CP template by querying the standalone CP cluster with the
+// given kubeclient.
+func PopulateHostedTemplateVars(ctx context.Context, kc *kubeclient.KubeClient) {
+	GinkgoHelper()
+
+	c := getAWSClusterClient(kc)
+	awsCluster, err := c.Get(ctx, os.Getenv(managedcluster.EnvVarHostedManagedClusterName), metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to get AWS cluster")
+
+	vpcID, found, err := unstructured.NestedString(awsCluster.Object, "spec.network.vpc.id")
+	Expect(err).NotTo(HaveOccurred(), "failed to get AWS cluster VPC ID")
+	Expect(found).To(BeTrue(), "AWS cluster has no VPC ID")
+
+	subnets, found, err := unstructured.NestedSlice(awsCluster.Object, "spec.network.subnets")
+	Expect(err).NotTo(HaveOccurred(), "failed to get AWS cluster subnets")
+	Expect(found).To(BeTrue(), "AWS cluster has no subnets")
+
+	subnet, ok := subnets[0].(map[string]interface{})
+	Expect(ok).To(BeTrue(), "failed to cast subnet to map")
+
+	subnetID, ok := subnet["id"].(string)
+	Expect(ok).To(BeTrue(), "failed to cast subnet ID to string")
+
+	subnetAZ, ok := subnet["availabilityZone"].(string)
+	Expect(ok).To(BeTrue(), "failed to cast subnet availability zone to string")
+
+	securityGroupID, found, err := unstructured.NestedString(
+		awsCluster.Object, "status.networkStatus.securityGroups.node.id")
+	Expect(err).NotTo(HaveOccurred(), "failed to get AWS cluster security group ID")
+	Expect(found).To(BeTrue(), "AWS cluster has no security group ID")
+
+	GinkgoT().Setenv(managedcluster.EnvVarAWSVPCID, vpcID)
+	GinkgoT().Setenv(managedcluster.EnvVarAWSSubnetID, subnetID)
+	GinkgoT().Setenv(managedcluster.EnvVarAWSSubnetAvailabilityZone, subnetAZ)
+	GinkgoT().Setenv(managedcluster.EnvVarAWSSecurityGroupID, securityGroupID)
+}
+
+func PatchAWSClusterReady(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) {
+	GinkgoHelper()
+
+	c := getAWSClusterClient(kc)
+
+	_, err := c.Patch(ctx, clusterName, types.MergePatchType,
+		[]byte("status: {ready: true}"), metav1.PatchOptions{}, "status")
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func getAWSClusterClient(kc *kubeclient.KubeClient) dynamic.ResourceInterface {
+	return kc.GetDynamicClient(schema.GroupVersionResource{
+		Group:    "infrastructure.cluster.x-k8s.io",
+		Version:  "v1",
+		Resource: "awsclusters",
+	})
+}

--- a/test/managedcluster/constants.go
+++ b/test/managedcluster/constants.go
@@ -1,0 +1,34 @@
+// Copyright 2024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedcluster
+
+const (
+	// Common
+	EnvVarManagedClusterName       = "MANAGED_CLUSTER_NAME"
+	EnvVarHostedManagedClusterName = "HOSTED_MANAGED_CLUSTER_NAME"
+	EnvVarInstallBeachHeadServices = "INSTALL_BEACH_HEAD_SERVICES"
+	EnvVarControlPlaneNumber       = "CONTROL_PLANE_NUMBER"
+	EnvVarWorkerNumber             = "WORKER_NUMBER"
+	EnvVarNamespace                = "NAMESPACE"
+
+	// AWS
+	EnvVarAWSVPCID                  = "AWS_VPC_ID"
+	EnvVarAWSSubnetID               = "AWS_SUBNET_ID"
+	EnvVarAWSSubnetAvailabilityZone = "AWS_SUBNET_AVAILABILITY_ZONE"
+	EnvVarAWSInstanceType           = "AWS_INSTANCE_TYPE"
+	EnvVarAWSSecurityGroupID        = "AWS_SG_ID"
+	EnvVarPublicIP                  = "AWS_PUBLIC_IP"
+	AWSCredentialsSecretName        = "aws-variables"
+)

--- a/test/managedcluster/managedcluster.go
+++ b/test/managedcluster/managedcluster.go
@@ -59,18 +59,31 @@ func GetProviderLabel(provider ProviderType) string {
 func GetUnstructured(provider ProviderType, templateName Template) *unstructured.Unstructured {
 	GinkgoHelper()
 
-	generatedName := uuid.New().String()[:8] + "-e2e-test"
-	_, _ = fmt.Fprintf(GinkgoWriter, "Generated cluster name: %q\n", generatedName)
+	generatedName := os.Getenv(EnvVarManagedClusterName)
+	if generatedName == "" {
+		generatedName = uuid.New().String()[:8] + "-e2e-test"
+		_, _ = fmt.Fprintf(GinkgoWriter, "Generated cluster name: %q\n", generatedName)
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using configured cluster name: %q\n", generatedName)
+		GinkgoT().Setenv(EnvVarManagedClusterName, generatedName)
+	}
 
 	switch provider {
 	case ProviderAWS:
-		Expect(os.Setenv("MANAGED_CLUSTER_NAME", generatedName)).NotTo(HaveOccurred())
-
 		var managedClusterTemplateBytes []byte
 		switch templateName {
 		case TemplateAWSStandaloneCP:
 			managedClusterTemplateBytes = awsStandaloneCPManagedClusterTemplateBytes
 		case TemplateAWSHostedCP:
+			GinkgoT().Setenv(EnvVarHostedManagedClusterName, generatedName+"-hosted")
+			// Validate environment vars that do not have defaults are populated.
+			validateDeploymentVars([]string{
+				EnvVarAWSVPCID,
+				EnvVarAWSSubnetID,
+				EnvVarAWSSubnetAvailabilityZone,
+				EnvVarAWSSecurityGroupID,
+			})
+
 			managedClusterTemplateBytes = awsHostedCPManagedClusterTemplateBytes
 		default:
 			Fail(fmt.Sprintf("unsupported AWS template: %s", templateName))
@@ -90,4 +103,12 @@ func GetUnstructured(provider ProviderType, templateName Template) *unstructured
 	}
 
 	return nil
+}
+
+func validateDeploymentVars(v []string) {
+	GinkgoHelper()
+
+	for _, envVar := range v {
+		Expect(os.Getenv(envVar)).NotTo(BeEmpty(), envVar+" must be set")
+	}
 }

--- a/test/managedcluster/resources/aws-hosted-cp.yaml.tpl
+++ b/test/managedcluster/resources/aws-hosted-cp.yaml.tpl
@@ -1,16 +1,16 @@
 apiVersion: hmc.mirantis.com/v1alpha1
 kind: ManagedCluster
 metadata:
-  name: ${MANAGED_CLUSTER_NAME}
+  name: ${HOSTED_MANAGED_CLUSTER_NAME}
 spec:
   template: aws-hosted-cp
   config:
     vpcID: ${AWS_VPC_ID}
     region: ${AWS_REGION}
-    publicIP: ${PUBLIC_IP:=true}
+    publicIP: ${AWS_PUBLIC_IP:=true}
     subnets:
       - id: ${AWS_SUBNET_ID}
         availabilityZone: ${AWS_SUBNET_AVAILABILITY_ZONE}
-    instanceType: ${INSTANCE_TYPE:=t3.medium}
+    instanceType: ${AWS_INSTANCE_TYPE:=t3.medium}
     securityGroupIDs:
       - ${AWS_SG_ID}

--- a/test/managedcluster/resources/aws-standalone-cp.yaml.tpl
+++ b/test/managedcluster/resources/aws-standalone-cp.yaml.tpl
@@ -6,12 +6,13 @@ spec:
   template: aws-standalone-cp
   config:
     region: ${AWS_REGION}
-    publicIP: ${PUBLIC_IP:=true}
+    publicIP: ${AWS_PUBLIC_IP:=true}
     controlPlaneNumber: ${CONTROL_PLANE_NUMBER:=1}
     workersNumber: ${WORKERS_NUMBER:=1}
     controlPlane:
-      instanceType: ${INSTANCE_TYPE:=t3.small}
+      instanceType: ${AWS_INSTANCE_TYPE:=t3.small}
     worker:
-      instanceType: ${INSTANCE_TYPE:=t3.small}
+      instanceType: ${AWS_INSTANCE_TYPE:=t3.small}
+    installBeachHeadServices: ${INSTALL_BEACH_HEAD_SERVICES:=true}
 
 

--- a/test/managedcluster/validate_deleted.go
+++ b/test/managedcluster/validate_deleted.go
@@ -40,10 +40,7 @@ func VerifyProviderDeleted(ctx context.Context, kc *kubeclient.KubeClient, clust
 // validateClusterDeleted validates that the Cluster resource has been deleted.
 func validateClusterDeleted(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
 	// Validate that the Cluster resource has been deleted
-	cluster, err := kc.GetCluster(ctx, clusterName)
-	if err != nil {
-		return err
-	}
+	cluster := kc.GetCluster(ctx, clusterName)
 
 	if cluster != nil {
 		phase, _, _ := unstructured.NestedString(cluster.Object, "status", "phase")
@@ -75,10 +72,7 @@ func validateClusterDeleted(ctx context.Context, kc *kubeclient.KubeClient, clus
 // validateMachineDeploymentsDeleted validates that all MachineDeployments have
 // been deleted.
 func validateMachineDeploymentsDeleted(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
-	machineDeployments, err := kc.ListMachineDeployments(ctx, clusterName)
-	if err != nil {
-		return err
-	}
+	machineDeployments := kc.ListMachineDeployments(ctx, clusterName)
 
 	var mdNames []string
 	if len(machineDeployments) > 0 {
@@ -95,10 +89,7 @@ func validateMachineDeploymentsDeleted(ctx context.Context, kc *kubeclient.KubeC
 // validateK0sControlPlanesDeleted validates that all k0scontrolplanes have
 // been deleted.
 func validateK0sControlPlanesDeleted(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
-	controlPlanes, err := kc.ListK0sControlPlanes(ctx, clusterName)
-	if err != nil {
-		return err
-	}
+	controlPlanes := kc.ListK0sControlPlanes(ctx, clusterName)
 
 	var cpNames []string
 	if len(controlPlanes) > 0 {

--- a/test/managedcluster/validate_deployed.go
+++ b/test/managedcluster/validate_deployed.go
@@ -83,10 +83,7 @@ func verifyProviderAction(
 }
 
 func validateCluster(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
-	cluster, err := kc.GetCluster(ctx, clusterName)
-	if err != nil {
-		return err
-	}
+	cluster := kc.GetCluster(ctx, clusterName)
 
 	phase, _, err := unstructured.NestedString(cluster.Object, "status", "phase")
 	if err != nil {
@@ -109,10 +106,7 @@ func validateCluster(ctx context.Context, kc *kubeclient.KubeClient, clusterName
 }
 
 func validateMachines(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
-	machines, err := kc.ListMachines(ctx, clusterName)
-	if err != nil {
-		return fmt.Errorf("failed to list machines: %w", err)
-	}
+	machines := kc.ListMachines(ctx, clusterName)
 
 	for _, machine := range machines {
 		if err := utils.ValidateObjectNamePrefix(&machine, clusterName); err != nil {
@@ -128,10 +122,7 @@ func validateMachines(ctx context.Context, kc *kubeclient.KubeClient, clusterNam
 }
 
 func validateK0sControlPlanes(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
-	controlPlanes, err := kc.ListK0sControlPlanes(ctx, clusterName)
-	if err != nil {
-		return fmt.Errorf("failed to list K0sControlPlanes: %w", err)
-	}
+	controlPlanes := kc.ListK0sControlPlanes(ctx, clusterName)
 
 	for _, controlPlane := range controlPlanes {
 		if err := utils.ValidateObjectNamePrefix(&controlPlane, clusterName); err != nil {
@@ -171,14 +162,11 @@ func validateK0sControlPlanes(ctx context.Context, kc *kubeclient.KubeClient, cl
 // validateCSIDriver validates that the provider CSI driver is functioning
 // by creating a PVC and verifying it enters "Bound" status.
 func validateCSIDriver(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
-	clusterKC, err := kc.NewFromCluster(ctx, "default", clusterName)
-	if err != nil {
-		Fail(fmt.Sprintf("failed to create KubeClient for managed cluster %s: %v", clusterName, err))
-	}
+	clusterKC := kc.NewFromCluster(ctx, "default", clusterName)
 
 	pvcName := clusterName + "-csi-test-pvc"
 
-	_, err = clusterKC.Client.CoreV1().PersistentVolumeClaims(clusterKC.Namespace).
+	_, err := clusterKC.Client.CoreV1().PersistentVolumeClaims(clusterKC.Namespace).
 		Create(ctx, &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: pvcName,
@@ -261,14 +249,11 @@ func validateCSIDriver(ctx context.Context, kc *kubeclient.KubeClient, clusterNa
 // functional by creating a LoadBalancer service and verifying it is assigned
 // an external IP.
 func validateCCM(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
-	clusterKC, err := kc.NewFromCluster(ctx, "default", clusterName)
-	if err != nil {
-		Fail(fmt.Sprintf("failed to create KubeClient for managed cluster %s: %v", clusterName, err))
-	}
+	clusterKC := kc.NewFromCluster(ctx, "default", clusterName)
 
 	createdServiceName := "loadbalancer-" + clusterName
 
-	_, err = clusterKC.Client.CoreV1().Services(clusterKC.Namespace).Create(ctx, &corev1.Service{
+	_, err := clusterKC.Client.CoreV1().Services(clusterKC.Namespace).Create(ctx, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: createdServiceName,
 		},

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -15,6 +15,7 @@
 package utils
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -27,8 +28,53 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// Run executes the provided command within this context
+// Run executes the provided command within this context and returns it's
+// output. Run does not wait for the command to finish, use Wait instead.
 func Run(cmd *exec.Cmd) ([]byte, error) {
+	command := prepareCmd(cmd)
+	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, handleCmdError(err, command)
+	}
+
+	return output, nil
+}
+
+// Wait executes the provided command within this context and waits for it to
+// finish. It then prints the output to the GinkgoWriter.
+func Wait(cmd *exec.Cmd) error {
+	command := prepareCmd(cmd)
+	_, _ = fmt.Fprintf(GinkgoWriter, "waiting on: %s\n", command)
+
+	buf := new(bytes.Buffer)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start command: %w", err)
+	}
+
+	// And when you need to wait for the command to finish:
+	if err := cmd.Wait(); err != nil {
+		return handleCmdError(err, command)
+	}
+
+	_, _ = fmt.Fprintf(GinkgoWriter, "%s output: %s\n", command, buf.String())
+
+	return nil
+}
+
+func handleCmdError(err error, command string) error {
+	var exitError *exec.ExitError
+
+	if errors.As(err, &exitError) {
+		return fmt.Errorf("%s failed with error: (%v): %s", command, err, string(exitError.Stderr))
+	}
+
+	return fmt.Errorf("%s failed with error: %w", command, err)
+}
+
+func prepareCmd(cmd *exec.Cmd) string {
 	dir, _ := GetProjectDir()
 	cmd.Dir = dir
 
@@ -37,19 +83,7 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 	}
 
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
-	command := strings.Join(cmd.Args, " ")
-	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
-
-	output, err := cmd.Output()
-	if err != nil {
-		var exitError *exec.ExitError
-
-		if errors.As(err, &exitError) {
-			return output, fmt.Errorf("%s failed with error: (%v): %s", command, err, string(exitError.Stderr))
-		}
-	}
-
-	return output, nil
+	return strings.Join(cmd.Args, " ")
 }
 
 // LoadImageToKindCluster loads a local docker image to the kind cluster


### PR DESCRIPTION
* Break KubeClient helpers into provider specific file
* Add cmd.Wait support and use it to wait for cloud-nuke to finish before trying to continue AfterAll's
* Finish aws-hosted-cp test and add comments through test to make it easier to understand.
* Use GinkgoHelper across e2e tests, populate hosted vars from AWSCluster.