### PR TITLE
Disable installBeachHeadServices by default on `aws-standalone-cp` template

### DIFF
--- a/config/dev/aws-managedcluster.yaml
+++ b/config/dev/aws-managedcluster.yaml
@@ -13,4 +13,5 @@ spec:
     worker:
       instanceType: t3.small
     workersNumber: 1
+    installBeachHeadServices: false
   template: aws-standalone-cp

--- a/templates/aws-standalone-cp/values.yaml
+++ b/templates/aws-standalone-cp/values.yaml
@@ -47,4 +47,4 @@ k0s:
 
 # Optionally install applications defined under 
 # templates/beachheadservices into target cluster
-installBeachHeadServices: true
+installBeachHeadServices: false


### PR DESCRIPTION
## Description
Disabling installBeachHeadServices by default on `aws-standalone-cp` template to address https://github.com/Mirantis/hmc/issues/286.