### PR TITLE
Install Sveltos as a Provider Template

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -23,3 +23,35 @@ type Providers struct {
 	// ControlPlaneProviders is the list of CAPI control plane providers
 	ControlPlaneProviders []string `json:"controlPlane,omitempty"`
 }
+
+const (
+	// Provider CAPA
+	ProviderCAPAName       = "cluster-api-provider-aws"
+	ProviderCAPASecretName = "aws-variables"
+	// Provider Azure
+	ProviderAzureName = "cluster-api-provider-azure"
+	// Provider K0smotron
+	ProviderK0smotronName = "k0smotron"
+	// Provider Sveltos
+	ProviderSveltosName            = "projectsveltos"
+	ProviderSveltosTargetNamespace = "projectsveltos"
+	ProviderSveltosCreateNamespace = true
+)
+
+var (
+	// DefaultProviders is a map of providers that are
+	// installed by default, each with its default config.
+	DefaultProviders = map[string]map[string]interface{}{
+		ProviderCAPAName: {
+			"configSecret": map[string]interface{}{
+				"name": ProviderCAPASecretName,
+			},
+		},
+		ProviderAzureName:     nil,
+		ProviderK0smotronName: nil,
+		ProviderSveltosName: {
+			"targetNamespace": ProviderSveltosTargetNamespace,
+			"createNamespace": ProviderSveltosCreateNamespace,
+		},
+	}
+)

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	v2 "github.com/fluxcd/helm-controller/api/v2"
@@ -39,8 +38,7 @@ import (
 )
 
 const (
-	defaultRepoName          = "hmc-templates"
-	defaultReconcileInterval = 10 * time.Minute
+	defaultRepoName = "hmc-templates"
 )
 
 // TemplateReconciler reconciles a Template object
@@ -291,7 +289,7 @@ func (r *TemplateReconciler) reconcileHelmChart(ctx context.Context, template Te
 				Kind: sourcev1.HelmRepositoryKind,
 				Name: defaultRepoName,
 			},
-			Interval: metav1.Duration{Duration: defaultReconcileInterval},
+			Interval: metav1.Duration{Duration: helm.DefaultReconcileInterval},
 		}
 		return nil
 	})

--- a/templates/provider/hmc-templates/files/templates/projectsveltos.yaml
+++ b/templates/provider/hmc-templates/files/templates/projectsveltos.yaml
@@ -1,0 +1,8 @@
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: ProviderTemplate
+metadata:
+  name: projectsveltos
+spec:
+  helm:
+    chartName: projectsveltos
+    chartVersion: 0.37.1

--- a/templates/provider/hmc-templates/files/templates/projectsveltos.yaml
+++ b/templates/provider/hmc-templates/files/templates/projectsveltos.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   helm:
     chartName: projectsveltos
-    chartVersion: 0.37.1
+    chartVersion: 0.38.1

--- a/templates/provider/projectsveltos/Chart.lock
+++ b/templates/provider/projectsveltos/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: projectsveltos
   repository: https://projectsveltos.github.io/helm-charts
-  version: 0.37.1
-digest: sha256:7cd26bda21bebdc3371a68c0abd5039d129a6b44bc6d83f6f985fdd4f5965ac3
-generated: "2024-09-11T17:09:38.776454-04:00"
+  version: 0.38.1
+digest: sha256:6fae3801c4b89a99b64a8185d21d6b12ec7cf4f40b15c5555985afa88894f4a8
+generated: "2024-09-13T11:52:06.517657-04:00"

--- a/templates/provider/projectsveltos/Chart.lock
+++ b/templates/provider/projectsveltos/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: projectsveltos
+  repository: https://projectsveltos.github.io/helm-charts
+  version: 0.37.1
+digest: sha256:7cd26bda21bebdc3371a68c0abd5039d129a6b44bc6d83f6f985fdd4f5965ac3
+generated: "2024-09-11T17:09:38.776454-04:00"

--- a/templates/provider/projectsveltos/Chart.yaml
+++ b/templates/provider/projectsveltos/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: projectsveltos
 description: A Helm chart to refer the official projectsveltos helm chart
 type: application
-version: 0.37.1
-appVersion: "0.37.0"
+version: 0.38.1
+appVersion: "0.38.1"
 dependencies:
   - name: projectsveltos
-    version: 0.37.1
+    version: 0.38.1
     repository: https://projectsveltos.github.io/helm-charts
 annotations:
   hmc.mirantis.com/type: provider

--- a/templates/provider/projectsveltos/Chart.yaml
+++ b/templates/provider/projectsveltos/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: projectsveltos
+description: A Helm chart to refer the official projectsveltos helm chart
+type: application
+version: 0.37.1
+appVersion: "0.37.0"
+dependencies:
+  - name: projectsveltos
+    version: 0.37.1
+    repository: https://projectsveltos.github.io/helm-charts
+annotations:
+  hmc.mirantis.com/type: provider


### PR DESCRIPTION
# Description
This fixes [#269](https://github.com/Mirantis/hmc/issues/269).

1. Sveltos is installed (via it's [helm chart](https://github.com/projectsveltos/helm-charts)) as a `provider` type template.
2. The reason it is installed as a separate template rather than as a subchart within the HMC template is because Sveltos needs to be installed in the `projectsveltos` namespace for it to function.
3. We already tried installing Sveltos in `hmc-system` namespace but it didn't work properly, the details of which can be [seen here](https://github.com/Mirantis/2a-internal/issues/5#issuecomment-2334128875).

# Manual Testing
Installed with AWS provider and waited for everything to be in running state.

## Management Cluster
- Verified that Sveltos template has been created:
```sh
➜  ~ kubectl get template -A
NAMESPACE    NAME                         TYPE         VALID
hmc-system   aws-hosted-cp                deployment   true
hmc-system   aws-standalone-cp            deployment   true
hmc-system   azure-hosted-cp              deployment   true
hmc-system   azure-standalone-cp          deployment   true
hmc-system   cluster-api                  core         true
hmc-system   cluster-api-provider-aws     provider     true
hmc-system   cluster-api-provider-azure   provider     true
hmc-system   hmc                          core         true
hmc-system   k0smotron                    provider     true
hmc-system   projectsveltos               provider     true
```
- Verified all `HelmReleases` have been successfully reconciled:
```sh
➜  ~ kubectl get helmreleases -A
NAMESPACE    NAME                         AGE   READY   STATUS
hmc-system   cluster-api                  15m   True    Helm install succeeded for release hmc-system/cluster-api.v1 with chart cluster-api@0.1.1
hmc-system   cluster-api-provider-aws     15m   True    Helm install succeeded for release hmc-system/cluster-api-provider-aws.v1 with chart cluster-api-provider-aws@0.1.1
hmc-system   cluster-api-provider-azure   15m   True    Helm install succeeded for release hmc-system/cluster-api-provider-azure.v1 with chart cluster-api-provider-azure@0.0.1
hmc-system   hmc                          15m   True    Helm upgrade succeeded for release hmc-system/hmc.v2 with chart hmc@0.1.0
hmc-system   k0smotron                    15m   True    Helm install succeeded for release hmc-system/k0smotron.v1 with chart k0smotron@0.1.3
hmc-system   projectsveltos               15m   True    Helm install succeeded for release projectsveltos/projectsveltos.v1 with chart projectsveltos@0.37.1
hmc-system   wali-aws-dev                 10m   True    Helm install succeeded for release hmc-system/wali-aws-dev.v1 with chart aws-standalone-cp@0.1.2
```
- Verified that components of Sveltos can be seen running in the `projectsveltos` namespace:
```sh
➜  ~ kubectl get deployments -A
NAMESPACE            NAME                                          READY   UP-TO-DATE   AVAILABLE   AGE
hmc-system           azureserviceoperator-controller-manager       1/1     1            1           12m
hmc-system           capa-controller-manager                       1/1     1            1           13m
hmc-system           capi-controller-manager                       1/1     1            1           14m
hmc-system           capz-controller-manager                       1/1     1            1           12m
hmc-system           helm-controller                               1/1     1            1           15m
hmc-system           hmc-cert-manager                              1/1     1            1           15m
hmc-system           hmc-cert-manager-cainjector                   1/1     1            1           15m
hmc-system           hmc-cert-manager-webhook                      1/1     1            1           15m
hmc-system           hmc-cluster-api-operator                      1/1     1            1           14m
hmc-system           hmc-controller-manager                        1/1     1            1           15m
hmc-system           k0smotron-controller-manager-bootstrap        1/1     1            1           13m
hmc-system           k0smotron-controller-manager-control-plane    1/1     1            1           13m
hmc-system           k0smotron-controller-manager-infrastructure   1/1     1            1           12m
hmc-system           source-controller                             1/1     1            1           15m
kube-system          coredns                                       2/2     2            2           16m
local-path-storage   local-path-provisioner                        1/1     1            1           16m
projectsveltos       access-manager                                1/1     1            1           13m
projectsveltos       addon-controller                              1/1     1            1           13m
projectsveltos       classifier-manager                            1/1     1            1           13m
projectsveltos       conversion-webhook                            1/1     1            1           13m
projectsveltos       event-manager                                 1/1     1            1           13m
projectsveltos       hc-manager                                    1/1     1            1           13m
projectsveltos       sc-manager                                    1/1     1            1           13m
projectsveltos       shard-controller                              1/1     1            1           13m
projectsveltos       sveltos-agent-manager                         1/1     1            1           12m
```
- Verified that Sveltos's default classifier has been installed:
```sh
➜  ~ kubectl get classifier
NAME                 AGE
default-classifier   13m
```
- Labeled the target cluster with `env=fv`:
```sh
➜  ~ kubectl get cluster -A --show-labels
NAMESPACE    NAME           CLUSTERCLASS   PHASE         AGE   VERSION   LABELS
hmc-system   wali-aws-dev                  Provisioned   11m             app.kubernetes.io/managed-by=Helm,env=fv,helm.toolkit.fluxcd.io/name=wali-aws-dev,helm.toolkit.fluxcd.io/namespace=hmc-system,sveltos-agent=present
```
- Finally created the following cluster profile:
```yaml
apiVersion: config.projectsveltos.io/v1beta1
kind: ClusterProfile
metadata:
  name: kyverno
spec:
  clusterSelector:
    matchLabels:
      env: fv
  helmCharts:
    - repositoryURL:    https://kyverno.github.io/kyverno/
      repositoryName:   kyverno
      chartName:        kyverno/kyverno
      chartVersion:     v3.2.5
      releaseName:      kyverno-latest
      releaseNamespace: kyverno
      helmChartAction:  Install
```
```sh
➜  ~ kubectl get clusterprofile                
NAME      AGE
kyverno   118m
```

## Target Cluster
As can be seen below, Sveltos is running in `projectsveltos` namespace and `kyverno` has also been installed in the target cluster.
```sh
➜  ~ kubectl get deployments -A
NAMESPACE        NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
kube-system      calico-kube-controllers         1/1     1            1           7m33s
kube-system      coredns                         2/2     2            2           7m37s
kube-system      ebs-csi-controller              2/2     2            2           7m17s
kube-system      metrics-server                  1/1     1            1           7m28s
kyverno          kyverno-admission-controller    1/1     1            1           40s
kyverno          kyverno-background-controller   1/1     1            1           40s
kyverno          kyverno-cleanup-controller      1/1     1            1           40s
kyverno          kyverno-reports-controller      1/1     1            1           40s
projectsveltos   sveltos-agent-manager           1/1     1            1           7m3s
```