### PR TITLE
Add vSphere e2e standalone test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,21 +293,25 @@ dev-aws-creds: yq
 dev-azure-creds: envsubst
 	@NAMESPACE=$(NAMESPACE) $(ENVSUBST) -no-unset -i config/dev/azure-credentials.yaml | $(KUBECTL) apply -f -
 
+.PHONY: dev-vsphere-creds
+dev-vsphere-creds: envsubst
+	@NAMESPACE=$(NAMESPACE) $(ENVSUBST) -no-unset -i config/dev/vsphere-credentials.yaml | $(KUBECTL) apply -f -
+
 .PHONY: dev-apply
 dev-apply: kind-deploy registry-deploy dev-push dev-deploy dev-templates
 
 .PHONY: dev-destroy
 dev-destroy: kind-undeploy registry-undeploy ## Destroy the development environment by deleting the kind cluster and local registry.
 
-.PHONY: dev-provider-apply
-dev-provider-apply: envsubst
+.PHONY: dev-mcluster-apply
+dev-mcluster-apply: envsubst
 	@if [ $(DEV_PROVIDER) = "aws" ]; then \
 		$(MAKE) dev-aws-creds; \
 	fi
 	@NAMESPACE=$(NAMESPACE) $(ENVSUBST) -no-unset -i config/dev/$(DEV_PROVIDER)-managedcluster.yaml | $(KUBECTL) apply -f -
 
-.PHONY: dev-provider-delete
-dev-provider-delete: envsubst
+.PHONY: dev-mcluster-delete
+dev-mcluster-delete: envsubst
 	@NAMESPACE=$(NAMESPACE) $(ENVSUBST) -no-unset -i config/dev/$(DEV_PROVIDER)-managedcluster.yaml | $(KUBECTL) delete -f -
 
 .PHONY: dev-creds-apply
@@ -319,12 +323,6 @@ dev-aws-nuke: ## Warning: Destructive! Nuke all AWS resources deployed by 'DEV_P
 	DISABLE_TELEMETRY=true $(CLOUDNUKE) aws --region $$AWS_REGION --force --config config/dev/cloud_nuke.yaml --resource-type vpc,eip,nat-gateway,ec2-subnet,elb,elbv2,internet-gateway,network-interface,security-group
 	@rm config/dev/cloud_nuke.yaml
 	@CLUSTER_NAME=$(CLUSTER_NAME) YQ=$(YQ) AWSCLI=$(AWSCLI) bash -c ./scripts/aws-nuke-ccm.sh
-
-.PHONY: test-apply
-test-apply: kind-deploy registry-deploy dev-push dev-deploy dev-templates
-
-.PHONY: test-destroy
-test-destroy: kind-undeploy registry-undeploy
 
 .PHONY: cli-install
 cli-install: clusterawsadm clusterctl cloud-nuke yq awscli ## Install the necessary CLI tools for deployment, development and testing.

--- a/config/dev/vsphere-credentials.yaml
+++ b/config/dev/vsphere-credentials.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereClusterIdentity
+metadata:
+  name: vsphere-cluster-identity
+  namespace: ${NAMESPACE}
+spec:
+  secretName: vsphere-cluster-identity-secret
+  allowedNamespaces:
+    selector:
+      matchLabels: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-cluster-identity-secret
+  namespace: ${NAMESPACE}
+stringData:
+  username: ${VSPHERE_USER}
+  password: ${VSPHERE_PASSWORD}

--- a/config/dev/vsphere-managedcluster.yaml
+++ b/config/dev/vsphere-managedcluster.yaml
@@ -1,0 +1,42 @@
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: ManagedCluster
+metadata:
+  name: vsphere-dev
+  namespace: ${NAMESPACE}
+spec:
+  template: vsphere-standalone-cp
+  config:
+    controlPlaneNumber: 1
+    workersNumber: 1
+    clusterIdentity:
+      name: vsphere-cluster-identity
+    vsphere:
+      server: ${VSPHERE_SERVER}
+      thumbprint: ${VSPHERE_THUMBPRINT} 
+      datacenter: ${VSPHERE_DATACENTER}
+      datastore: ${VSPHERE_DATASTORE}
+      resourcePool: ${VSPHERE_RESOURCEPOOL}
+      folder: ${VSPHERE_FOLDER}
+      username: ${VSPHERE_USER}
+      password: ${VSPHERE_PASSWORD}
+    controlPlaneEndpointIP: ${VSPHERE_CONTROL_PLANE_ENDPOINT}
+    
+    controlPlane:
+      ssh:
+        user: ubuntu
+        publicKey: ${VSPHERE_SSH_KEY}
+      rootVolumeSize: 50
+      cpus: 4
+      memory: 4096
+      vmTemplate: ${VSPHERE_VM_TEMPLATE}
+      network: ${VSPHERE_NETWORK}
+
+    worker:
+      ssh:
+        user: ubuntu
+        publicKey: ${VSPHERE_SSH_KEY}
+      rootVolumeSize: 50
+      cpus: 4
+      memory: 4096
+      vmTemplate: ${VSPHERE_VM_TEMPLATE}
+      network: ${VSPHERE_NETWORK}

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -38,6 +38,30 @@ be set before running deployment:
 More detailed description of these parameters can be found
 [here](azure/cluster-parameters.md).
 
+### vSphere Provider Setup
+
+Follow the instruction on how to configure [vSphere Provider](vsphere/main.md).
+
+To properly deploy dev cluster you need to have the following variables set:
+
+- `VSPHERE_USER`
+- `VSPHERE_PASSWORD`
+- `VSPHERE_SERVER`
+- `VSPHERE_THUMBPRINT`
+- `VSPHERE_DATACENTER`
+- `VSPHERE_DATASTORE`
+- `VSPHERE_RESOURCEPOOL`
+- `VSPHERE_FOLDER`
+- `VSPHERE_CONTROL_PLANE_ENDPOINT`
+- `VSPHERE_VM_TEMPLATE`
+- `VSPHERE_NETWORK`
+- `VSPHERE_SSH_KEY`
+
+Naming of the variables duplicates parameters in `ManagementCluster`. To get
+full explanation for each parameter visit
+[vSphere cluster parameters](cluster-parameters.md) and
+[vSphere machine parameters](machine-parameters.md).
+
 ## Deploy HMC
 
 Default provider which will be used to deploy cluster is AWS, if you want to use
@@ -57,7 +81,7 @@ running make (e.g. `export DEV_PROVIDER=azure`).
 
 4. Apply credentials for your provider by executing `make dev-creds-apply`.
 
-5. Run `make dev-provider-apply` to deploy managed cluster on provider of your
+5. Run `make dev-mcluster-apply` to deploy managed cluster on provider of your
    choice with default configuration.
 
 6. Wait for infrastructure to be provisioned and the cluster to be deployed. You

--- a/test/kubeclient/kubeclient.go
+++ b/test/kubeclient/kubeclient.go
@@ -154,6 +154,75 @@ func (kc *KubeClient) CreateAWSCredentialsKubeSecret(ctx context.Context) error 
 	return nil
 }
 
+func (kc *KubeClient) CreateVSphereSecret(secretName string) error {
+	ctx := context.Background()
+	_, err := kc.Client.CoreV1().Secrets(kc.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+
+	if !apierrors.IsNotFound(err) {
+		return nil
+	}
+	username := os.Getenv("VSPHERE_USER")
+	password := os.Getenv("VSPHERE_PASSWORD")
+
+	_, err = kc.Client.CoreV1().Secrets(kc.Namespace).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretName,
+		},
+		StringData: map[string]string{
+			"username": username,
+			"password": password,
+		},
+		Type: corev1.SecretTypeOpaque,
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		return fmt.Errorf("failed to create vSphere credentials secret: %w", err)
+	}
+
+	return nil
+}
+
+func (kc *KubeClient) CreateVSphereClusterIdentity(secretName string, identityName string) error {
+	ctx := context.Background()
+	client, err := dynamic.NewForConfig(kc.Config)
+
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "infrastructure.cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "vsphereclusteridentities",
+	}
+
+	clusterIdentity := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+			"kind":       "VSphereClusterIdentity",
+			"metadata": map[string]interface{}{
+				"name": identityName,
+			},
+			"spec": map[string]interface{}{
+				"secretName": secretName,
+				"allowedNamespaces": map[string]interface{}{
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := client.Resource(gvr).Create(ctx, clusterIdentity, metav1.CreateOptions{})
+	if err != nil {
+		fmt.Printf("%+v", result)
+		return fmt.Errorf("Failed to create vsphereclusteridentity: %w", err)
+	}
+
+	return nil
+}
+
 // GetDynamicClient returns a dynamic client for the given GroupVersionResource.
 func (kc *KubeClient) GetDynamicClient(gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error) {
 	client, err := dynamic.NewForConfig(kc.Config)

--- a/test/managedcluster/resources/vsphere-hosted-cp.yaml.tpl
+++ b/test/managedcluster/resources/vsphere-hosted-cp.yaml.tpl
@@ -1,0 +1,35 @@
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: ManagedCluster
+metadata:
+  name: ${MANAGED_CLUSTER_NAME}
+spec:
+  template: vsphere-hosted-cp
+  config:
+    controlPlaneNumber: ${CONTROL_PLANE_NUMBER:=1}
+    workersNumber: ${WORKERS_NUMBER:=1}
+    clusterIdentity:
+      name: "${VSPHERE_CLUSTER_IDENTITY}"
+    vsphere:
+      server: "${VSPHERE_SERVER}"
+      thumbprint: "${VSPHERE_THUMBPRINT} "
+      datacenter: "${VSPHERE_DATACENTER}"
+      datastore: "${VSPHERE_DATASTORE}"
+      resourcePool: "${VSPHERE_RESOURCEPOOL}"
+      folder: "${VSPHERE_FOLDER}"
+      username: "${VSPHERE_USER}"
+      password: "${VSPHERE_PASSWORD}"
+    controlPlaneEndpointIP: "${VSPHERE_CONTROL_PLANE_ENDPOINT}"
+
+    ssh:
+      user: ubuntu
+      publicKey: "${VSPHERE_SSH_KEY}"
+    rootVolumeSize: 50
+    cpus: 4
+    memory: 4096
+    vmTemplate: "${VSPHERE_VM_TEMPLATE}"
+    network: "${VSPHERE_NETWORK}"
+
+    k0smotron:
+      service:
+        annotations:
+          kube-vip.io/loadbalancerIPs: "${VSPHERE_CONTROL_PLANE_ENDPOINT}"

--- a/test/managedcluster/resources/vsphere-standalone-cp.yaml.tpl
+++ b/test/managedcluster/resources/vsphere-standalone-cp.yaml.tpl
@@ -1,0 +1,41 @@
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: ManagedCluster
+metadata:
+  name: ${MANAGED_CLUSTER_NAME}
+spec:
+  template: vsphere-standalone-cp
+  config:
+    controlPlaneNumber: ${CONTROL_PLANE_NUMBER:=1}
+    workersNumber: ${WORKERS_NUMBER:=1}
+    clusterIdentity:
+      name: "${VSPHERE_CLUSTER_IDENTITY}"
+    vsphere:
+      server: "${VSPHERE_SERVER}"
+      thumbprint: "${VSPHERE_THUMBPRINT} "
+      datacenter: "${VSPHERE_DATACENTER}"
+      datastore: "${VSPHERE_DATASTORE}"
+      resourcePool: "${VSPHERE_RESOURCEPOOL}"
+      folder: "${VSPHERE_FOLDER}"
+      username: "${VSPHERE_USER}"
+      password: "${VSPHERE_PASSWORD}"
+    controlPlaneEndpointIP: "${VSPHERE_CONTROL_PLANE_ENDPOINT}"
+
+    controlPlane:
+      ssh:
+        user: ubuntu
+        publicKey: "${VSPHERE_SSH_KEY}"
+      rootVolumeSize: 50
+      cpus: 4
+      memory: 4096
+      vmTemplate: "${VSPHERE_VM_TEMPLATE}"
+      network: "${VSPHERE_NETWORK}"
+
+    worker:
+      ssh:
+        user: ubuntu
+        publicKey: "${VSPHERE_SSH_KEY}"
+      rootVolumeSize: 50
+      cpus: 4
+      memory: 4096
+      vmTemplate: "${VSPHERE_VM_TEMPLATE}"
+      network: "${VSPHERE_NETWORK}"

--- a/test/managedcluster/validate_deleted.go
+++ b/test/managedcluster/validate_deleted.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Mirantis/hmc/test/kubeclient"
 	"github.com/Mirantis/hmc/test/utils"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -41,7 +42,7 @@ func VerifyProviderDeleted(ctx context.Context, kc *kubeclient.KubeClient, clust
 func validateClusterDeleted(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
 	// Validate that the Cluster resource has been deleted
 	cluster, err := kc.GetCluster(ctx, clusterName)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 
@@ -76,7 +77,7 @@ func validateClusterDeleted(ctx context.Context, kc *kubeclient.KubeClient, clus
 // been deleted.
 func validateMachineDeploymentsDeleted(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
 	machineDeployments, err := kc.ListMachineDeployments(ctx, clusterName)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 
@@ -96,7 +97,7 @@ func validateMachineDeploymentsDeleted(ctx context.Context, kc *kubeclient.KubeC
 // been deleted.
 func validateK0sControlPlanesDeleted(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
 	controlPlanes, err := kc.ListK0sControlPlanes(ctx, clusterName)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 

--- a/test/managedcluster/validate_deployed.go
+++ b/test/managedcluster/validate_deployed.go
@@ -45,9 +45,16 @@ var resourceValidators = map[string]resourceValidationFunc{
 // VerifyProviderDeployed is a provider-agnostic verification that checks
 // to ensure generic resources managed by the provider have been deleted.
 // It is intended to be used in conjunction with an Eventually block.
-func VerifyProviderDeployed(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
-	return verifyProviderAction(ctx, kc, clusterName, resourceValidators,
-		[]string{"clusters", "machines", "control-planes", "csi-driver", "ccm"})
+func VerifyProviderDeployed(
+	ctx context.Context, kc *kubeclient.KubeClient, clusterName string,
+	providerType ProviderType) error {
+	if providerType == ProviderVSphere {
+		return verifyProviderAction(ctx, kc, clusterName, resourceValidators,
+			[]string{"clusters", "machines", "control-planes", "csi-driver"})
+	} else {
+		return verifyProviderAction(ctx, kc, clusterName, resourceValidators,
+			[]string{"clusters", "machines", "control-planes", "csi-driver", "ccm"})
+	}
 }
 
 // verifyProviderAction is a provider-agnostic verification that checks for

--- a/test/utils/vsphere/vsphere.go
+++ b/test/utils/vsphere/vsphere.go
@@ -1,0 +1,44 @@
+// Copyright 2024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphereutils
+
+import (
+	"fmt"
+	"os"
+)
+
+func CheckEnv() error {
+	envVars := []string{
+		"VSPHERE_USER",
+		"VSPHERE_PASSWORD",
+		"VSPHERE_SERVER",
+		"VSPHERE_THUMBPRINT",
+		"VSPHERE_DATACENTER",
+		"VSPHERE_DATASTORE",
+		"VSPHERE_RESOURCEPOOL",
+		"VSPHERE_FOLDER",
+		"VSPHERE_CONTROL_PLANE_ENDPOINT",
+		"VSPHERE_VM_TEMPLATE",
+		"VSPHERE_NETWORK",
+		"VSPHERE_SSH_KEY",
+	}
+	for _, envVar := range envVars {
+		_, exists := os.LookupEnv(envVar)
+		if !exists {
+			return fmt.Errorf("Variable %s isn't set", envVar)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Partially resolves #254 , since it doesn't include hosted CP test.

Notes:

- To run the test `TEST_VSPHERE` must be set to any value, otherwise it will be skipped, since it will fail without special runner.
- CCM validation disabled, LodaBalancer Service is not created by CCM (and kube-vip requires an annotation) thus this test will fail.
- cluster identity is created using unstructured nonsense, because I don't see how to force client-go to use normal types without mangling with restclient (which doesn't look much better than the unstructured nonsense).

