### PR TITLE
Get status.conditions from CAPI operator during `updateComponentsStatus`

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -226,6 +226,7 @@ func main() {
 		Client:                   mgr.GetClient(),
 		Scheme:                   mgr.GetScheme(),
 		Config:                   mgr.GetConfig(),
+		DynamicClient:            dc,
 		SystemNamespace:          currentNamespace,
 		CreateTemplateManagement: createTemplateManagement,
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/controller/managedcluster_controller.go
+++ b/internal/controller/managedcluster_controller.go
@@ -109,7 +109,7 @@ func (r *ManagedClusterReconciler) setStatusFromClusterStatus(
 ) (bool, error) {
 	l := ctrl.LoggerFrom(ctx)
 
-	resourceConditions, err := status.GetResourceConditions(ctx, r.DynamicClient, schema.GroupVersionResource{
+	resourceConditions, err := status.GetResourceConditions(ctx, managedCluster.Namespace, r.DynamicClient, schema.GroupVersionResource{
 		Group:    "cluster.x-k8s.io",
 		Version:  "v1beta1",
 		Resource: "clusters",

--- a/internal/controller/managedcluster_controller.go
+++ b/internal/controller/managedcluster_controller.go
@@ -109,7 +109,7 @@ func (r *ManagedClusterReconciler) setStatusFromClusterStatus(
 ) (bool, error) {
 	l := ctrl.LoggerFrom(ctx)
 
-	_, _, conditions, err := status.ConditionsFromResource(ctx, r.DynamicClient, schema.GroupVersionResource{
+	resourceConditions, err := status.GetResourceConditions(ctx, r.DynamicClient, schema.GroupVersionResource{
 		Group:    "cluster.x-k8s.io",
 		Version:  "v1beta1",
 		Resource: "clusters",
@@ -124,7 +124,7 @@ func (r *ManagedClusterReconciler) setStatusFromClusterStatus(
 	}
 
 	allConditionsComplete := true
-	for _, metaCondition := range conditions {
+	for _, metaCondition := range resourceConditions.Conditions {
 		if metaCondition.Status != "True" {
 			allConditionsComplete = false
 		}

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	fluxv2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/pkg/apis/meta"
@@ -30,6 +31,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +42,7 @@ import (
 	"github.com/Mirantis/hmc/internal/certmanager"
 	"github.com/Mirantis/hmc/internal/helm"
 	"github.com/Mirantis/hmc/internal/utils"
+	"github.com/Mirantis/hmc/internal/utils/status"
 )
 
 // Those are only needed for the initial installation
@@ -56,6 +60,7 @@ type ManagementReconciler struct {
 	Scheme                   *runtime.Scheme
 	Config                   *rest.Config
 	SystemNamespace          string
+	DynamicClient            *dynamic.DynamicClient
 	CreateTemplateManagement bool
 }
 
@@ -154,6 +159,16 @@ func (r *ManagementReconciler) Update(ctx context.Context, management *hmc.Manag
 			errs = errors.Join(errs, errors.New(errMsg))
 			continue
 		}
+
+		if component.Template != hmc.CoreHMCName {
+			if err := r.checkProviderStatus(ctx, component.Template); err != nil {
+				errMsg := err.Error()
+				updateComponentsStatus(detectedComponents, &detectedProviders, detectedContracts, component.helmReleaseName, component.Template, template.Status.Providers, template.Status.CAPIContracts, errMsg)
+				errs = errors.Join(errs, errors.New(errMsg))
+				continue
+			}
+		}
+
 		updateComponentsStatus(detectedComponents, &detectedProviders, detectedContracts, component.helmReleaseName, component.Template, template.Status.Providers, template.Status.CAPIContracts, "")
 	}
 
@@ -206,6 +221,58 @@ func (r *ManagementReconciler) ensureTemplateManagement(ctx context.Context, mgm
 		return fmt.Errorf("failed to create %s TemplateManagement object: %w", hmc.TemplateManagementName, err)
 	}
 	l.Info("Successfully created TemplateManagement object")
+
+	return nil
+}
+
+// checkProviderStatus checks the status of a provider associated with a given
+// ProviderTemplate name.  Since there's no way to determine resource Kind from
+// the given template iterate over all possible provider types.
+func (r *ManagementReconciler) checkProviderStatus(ctx context.Context, providerTemplateName string) error {
+	var errs error
+
+	for _, resourceType := range []string{
+		"coreproviders",
+		"infrastructureproviders",
+		"controlplaneproviders",
+		"bootstrapproviders",
+	} {
+		gvr := schema.GroupVersionResource{
+			Group:    "operator.cluster.x-k8s.io",
+			Version:  "v1alpha2",
+			Resource: resourceType,
+		}
+
+		name, kind, conditions, err := status.ConditionsFromResource(ctx, r.DynamicClient, gvr,
+			labels.SelectorFromSet(map[string]string{hmc.FluxHelmChartNameKey: providerTemplateName}).String(),
+		)
+		if err != nil {
+			notFoundErr := status.ResourceNotFoundError{}
+			if errors.As(err, &notFoundErr) {
+				// Check the next resource type.
+				continue
+			}
+
+			return fmt.Errorf("failed to get status for template: %s: %w", providerTemplateName, err)
+		}
+
+		var falseConditionTypes []string
+		for _, condition := range conditions {
+			if condition.Status != metav1.ConditionTrue {
+				falseConditionTypes = append(falseConditionTypes, condition.Type)
+			}
+		}
+
+		if len(falseConditionTypes) > 0 {
+			errs = errors.Join(fmt.Errorf("%s: %s is not yet ready, has false conditions: %s",
+				name, kind, strings.Join(falseConditionTypes, ", ")))
+		}
+	}
+
+	if errs != nil {
+		return errs
+	}
+
 	return nil
 }
 

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -162,9 +162,8 @@ func (r *ManagementReconciler) Update(ctx context.Context, management *hmc.Manag
 
 		if component.Template != hmc.CoreHMCName {
 			if err := r.checkProviderStatus(ctx, component.Template); err != nil {
-				errMsg := err.Error()
-				updateComponentsStatus(detectedComponents, &detectedProviders, detectedContracts, component.helmReleaseName, component.Template, template.Status.Providers, template.Status.CAPIContracts, errMsg)
-				errs = errors.Join(errs, errors.New(errMsg))
+				updateComponentsStatus(detectedComponents, &detectedProviders, detectedContracts, component.helmReleaseName, component.Template, template.Status.Providers, template.Status.CAPIContracts, err.Error())
+				errs = errors.Join(errs, err)
 				continue
 			}
 		}
@@ -243,7 +242,7 @@ func (r *ManagementReconciler) checkProviderStatus(ctx context.Context, provider
 			Resource: resourceType,
 		}
 
-		name, kind, conditions, err := status.ConditionsFromResource(ctx, r.DynamicClient, gvr,
+		resourceConditions, err := status.GetResourceConditions(ctx, r.DynamicClient, gvr,
 			labels.SelectorFromSet(map[string]string{hmc.FluxHelmChartNameKey: providerTemplateName}).String(),
 		)
 		if err != nil {
@@ -257,7 +256,7 @@ func (r *ManagementReconciler) checkProviderStatus(ctx context.Context, provider
 		}
 
 		var falseConditionTypes []string
-		for _, condition := range conditions {
+		for _, condition := range resourceConditions.Conditions {
 			if condition.Status != metav1.ConditionTrue {
 				falseConditionTypes = append(falseConditionTypes, condition.Type)
 			}
@@ -265,7 +264,7 @@ func (r *ManagementReconciler) checkProviderStatus(ctx context.Context, provider
 
 		if len(falseConditionTypes) > 0 {
 			errs = errors.Join(fmt.Errorf("%s: %s is not yet ready, has false conditions: %s",
-				name, kind, strings.Join(falseConditionTypes, ", ")))
+				resourceConditions.Name, resourceConditions.Kind, strings.Join(falseConditionTypes, ", ")))
 		}
 	}
 

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -242,7 +242,7 @@ func (r *ManagementReconciler) checkProviderStatus(ctx context.Context, provider
 			Resource: resourceType,
 		}
 
-		resourceConditions, err := status.GetResourceConditions(ctx, r.DynamicClient, gvr,
+		resourceConditions, err := status.GetResourceConditions(ctx, r.SystemNamespace, r.DynamicClient, gvr,
 			labels.SelectorFromSet(map[string]string{hmc.FluxHelmChartNameKey: providerTemplateName}).String(),
 		)
 		if err != nil {

--- a/internal/utils/status/status.go
+++ b/internal/utils/status/status.go
@@ -85,10 +85,12 @@ type ResourceConditions struct {
 // If the resource is not found, returns a ResourceNotFoundError which can be
 // checked by the caller to prevent reconciliation loops.
 func GetResourceConditions(
-	ctx context.Context, dynamicClient dynamic.Interface,
+	ctx context.Context, namespace string, dynamicClient dynamic.Interface,
 	gvr schema.GroupVersionResource, labelSelector string,
 ) (resourceConditions *ResourceConditions, err error) {
-	list, err := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{LabelSelector: labelSelector, Limit: 2})
+	list, err := dynamicClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector, Limit: 2,
+	})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, ResourceNotFoundError{Resource: gvr.Resource}

--- a/internal/utils/status/status.go
+++ b/internal/utils/status/status.go
@@ -1,0 +1,117 @@
+// Copyright 2024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// ConditionsFromUnstructured fetches all of the status.conditions from an
+// unstructured object and returns them as a slice of metav1.Condition.  The
+// status.conditions field is expected to be a slice of map[string]any
+// which can be cast into a metav1.Condition.
+func ConditionsFromUnstructured(unstrObj *unstructured.Unstructured) ([]metav1.Condition, error) {
+	objKind, objName := ObjKindName(unstrObj)
+
+	// Iterate the status conditions and ensure each condition reports a "Ready"
+	// status.
+	unstrConditions, found, err := unstructured.NestedSlice(unstrObj.Object, "status", "conditions")
+	if !found {
+		return nil, fmt.Errorf("no status conditions found for %s: %s", objKind, objName)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get status conditions for %s: %s: %w", objKind, objName, err)
+	}
+
+	conditions := make([]metav1.Condition, 0, len(unstrConditions))
+
+	for _, condition := range unstrConditions {
+		conditionMap, ok := condition.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("expected %s: %s condition to be type map[string]any, got: %T",
+				objKind, objName, conditionMap)
+		}
+
+		var c *metav1.Condition
+
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(conditionMap, &c); err != nil {
+			return nil, fmt.Errorf("failed to convert condition map to metav1.Condition: %w", err)
+		}
+
+		conditions = append(conditions, *c)
+	}
+
+	return conditions, nil
+}
+
+type ResourceNotFoundError struct {
+	Resource string
+}
+
+func (e ResourceNotFoundError) Error() string {
+	return fmt.Sprintf("no %s found, ignoring since object must be deleted or not yet created", e.Resource)
+}
+
+// ConditionsFromResource fetches the conditions from a resource identified by
+// the provided GroupVersionResource and labelSelector.  The function returns
+// the name and kind of the resource and a slice of metav1.Condition.  If the
+// resource is not found, returns a ResourceNotFoundError which can be checked
+// by the caller to prevent reconciliation loops.
+//
+//nolint:revive
+func ConditionsFromResource(
+	ctx context.Context, dynamicClient dynamic.Interface,
+	gvr schema.GroupVersionResource, labelSelector string,
+) (string, string, []metav1.Condition, error) {
+	list, err := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", "", nil, ResourceNotFoundError{Resource: gvr.Resource}
+		}
+
+		return "", "", nil, fmt.Errorf("failed to list %s: %w", gvr.Resource, err)
+	}
+
+	if len(list.Items) == 0 {
+		return "", "", nil, ResourceNotFoundError{Resource: gvr.Resource}
+	}
+
+	if len(list.Items) > 1 {
+		return "", "", nil, fmt.Errorf("expected to find only one of resource: %s with label: %q, found: %d",
+			gvr.Resource, labelSelector, len(list.Items))
+	}
+
+	kind, name := ObjKindName(&list.Items[0])
+	conditions, err := ConditionsFromUnstructured(&list.Items[0])
+	if err != nil {
+		return "", "", nil, fmt.Errorf("failed to get conditions: %w", err)
+	}
+
+	return kind, name, conditions, nil
+}
+
+func ObjKindName(unstrObj *unstructured.Unstructured) (name string, kind string) {
+	kind = unstrObj.GetKind()
+	name = unstrObj.GetName()
+	return kind, name
+}

--- a/internal/utils/status/status.go
+++ b/internal/utils/status/status.go
@@ -121,8 +121,6 @@ func GetResourceConditions(
 	}, nil
 }
 
-func ObjKindName(unstrObj *unstructured.Unstructured) (name string, kind string) {
-	kind = unstrObj.GetKind()
-	name = unstrObj.GetName()
-	return kind, name
+func ObjKindName(unstrObj *unstructured.Unstructured) (name, kind string) {
+	return unstrObj.GetKind(), unstrObj.GetName()
 }

--- a/templates/provider/hmc/templates/rbac/controller/roles.yaml
+++ b/templates/provider/hmc/templates/rbac/controller/roles.yaml
@@ -6,6 +6,16 @@ metadata:
   {{- include "hmc.labels" . | nindent 4 }}
 rules:
 - apiGroups:
+  - operator.cluster.x-k8s.io
+  resources:
+  - coreproviders
+  - infrastructureproviders
+  - bootstrapproviders
+  - controlplaneproviders
+  verbs:
+  - get
+  - list
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusters

--- a/test/e2e/kubeclient/kubeclient.go
+++ b/test/e2e/kubeclient/kubeclient.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/Mirantis/hmc/test/utils"
+	"github.com/Mirantis/hmc/internal/utils/status"
 )
 
 type KubeClient struct {
@@ -162,7 +162,7 @@ func (kc *KubeClient) CreateOrUpdateUnstructuredObject(gvr schema.GroupVersionRe
 
 	client := kc.GetDynamicClient(gvr, namespaced)
 
-	kind, name := utils.ObjKindName(obj)
+	kind, name := status.ObjKindName(obj)
 
 	resp, err := client.Get(context.Background(), name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {

--- a/test/e2e/managedcluster/validate_deleted.go
+++ b/test/e2e/managedcluster/validate_deleted.go
@@ -22,6 +22,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/Mirantis/hmc/internal/utils/status"
 	"github.com/Mirantis/hmc/test/e2e/kubeclient"
 	"github.com/Mirantis/hmc/test/utils"
 )
@@ -44,7 +45,7 @@ func validateClusterDeleted(ctx context.Context, kc *kubeclient.KubeClient, clus
 			return fmt.Errorf("cluster: %q exists, but is not in 'Deleting' phase", clusterName)
 		}
 
-		conditions, err := utils.GetConditionsFromUnstructured(cluster)
+		conditions, err := status.ConditionsFromUnstructured(cluster)
 		if err != nil {
 			return fmt.Errorf("failed to get conditions from unstructured object: %w", err)
 		}

--- a/test/e2e/managedcluster/validate_deployed.go
+++ b/test/e2e/managedcluster/validate_deployed.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/Mirantis/hmc/internal/utils/status"
 	"github.com/Mirantis/hmc/test/e2e/kubeclient"
 	"github.com/Mirantis/hmc/test/utils"
 )
@@ -108,12 +109,12 @@ func validateK0sControlPlanes(ctx context.Context, kc *kubeclient.KubeClient, cl
 			Fail(err.Error())
 		}
 
-		objKind, objName := utils.ObjKindName(&controlPlane)
+		objKind, objName := status.ObjKindName(&controlPlane)
 
 		// k0s does not use the metav1.Condition type for status.conditions,
 		// instead it uses a custom type so we can't use
 		// ValidateConditionsTrue here, instead we'll check for "ready: true".
-		status, found, err := unstructured.NestedFieldCopy(controlPlane.Object, "status")
+		objStatus, found, err := unstructured.NestedFieldCopy(controlPlane.Object, "status")
 		if !found {
 			return fmt.Errorf("no status found for %s: %s", objKind, objName)
 		}
@@ -121,9 +122,9 @@ func validateK0sControlPlanes(ctx context.Context, kc *kubeclient.KubeClient, cl
 			return fmt.Errorf("failed to get status conditions for %s: %s: %w", objKind, objName, err)
 		}
 
-		st, ok := status.(map[string]any)
+		st, ok := objStatus.(map[string]any)
 		if !ok {
-			return fmt.Errorf("expected K0sControlPlane condition to be type map[string]any, got: %T", status)
+			return fmt.Errorf("expected K0sControlPlane condition to be type map[string]any, got: %T", objStatus)
 		}
 
 		if _, ok := st["ready"]; !ok {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -24,7 +24,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Mirantis/hmc/internal/utils/status"
 )
 
 const (
@@ -114,9 +115,9 @@ func GetProjectDir() (string, error) {
 // unstructured object and returns an error if any of the conditions are not
 // true.  Conditions are expected to be of type metav1.Condition.
 func ValidateConditionsTrue(unstrObj *unstructured.Unstructured) error {
-	objKind, objName := ObjKindName(unstrObj)
+	objKind, objName := status.ObjKindName(unstrObj)
 
-	conditions, err := GetConditionsFromUnstructured(unstrObj)
+	conditions, err := status.ConditionsFromUnstructured(unstrObj)
 	if err != nil {
 		return fmt.Errorf("failed to get conditions from unstructured object: %w", err)
 	}
@@ -143,43 +144,9 @@ func ConvertConditionsToString(condition metav1.Condition) string {
 		condition.Type, condition.Status, condition.Reason, condition.Message)
 }
 
-func GetConditionsFromUnstructured(unstrObj *unstructured.Unstructured) ([]metav1.Condition, error) {
-	objKind, objName := ObjKindName(unstrObj)
-
-	// Iterate the status conditions and ensure each condition reports a "Ready"
-	// status.
-	unstrConditions, found, err := unstructured.NestedSlice(unstrObj.Object, "status", "conditions")
-	if !found {
-		return nil, fmt.Errorf("no status conditions found for %s: %s", objKind, objName)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to get status conditions for %s: %s: %w", objKind, objName, err)
-	}
-
-	conditions := make([]metav1.Condition, 0, len(unstrConditions))
-
-	for _, condition := range unstrConditions {
-		conditionMap, ok := condition.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("expected %s: %s condition to be type map[string]any, got: %T",
-				objKind, objName, conditionMap)
-		}
-
-		var c *metav1.Condition
-
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(conditionMap, &c); err != nil {
-			return nil, fmt.Errorf("failed to convert condition map to metav1.Condition: %w", err)
-		}
-
-		conditions = append(conditions, *c)
-	}
-
-	return conditions, nil
-}
-
 // ValidateObjectNamePrefix checks if the given object name has the given prefix.
 func ValidateObjectNamePrefix(unstrObj *unstructured.Unstructured, clusterName string) error {
-	objKind, objName := ObjKindName(unstrObj)
+	objKind, objName := status.ObjKindName(unstrObj)
 
 	// Verify the machines are prefixed with the cluster name and fail
 	// the test if they are not.
@@ -188,10 +155,6 @@ func ValidateObjectNamePrefix(unstrObj *unstructured.Unstructured, clusterName s
 	}
 
 	return nil
-}
-
-func ObjKindName(unstrObj *unstructured.Unstructured) (kind, name string) {
-	return unstrObj.GetKind(), unstrObj.GetName()
 }
 
 func WarnError(err error) {


### PR DESCRIPTION
In this PR we now update our component statuses by iterating the provider CRDs affiliated with CAPI operator and returning a status error if any of the `status.conditions` are `False` or if we cannot obtain any information pertaining to status condition.  For example:

In this case `cluster-api-provider-aws` and `-azure` are not yet installed:

```
  status:
    availableProviders: {}
    components:
      cluster-api:
        success: true
      cluster-api-provider-aws:
        error: 'failed to find any provider resources affiliated with template: cluster-api-provider-aws'
      cluster-api-provider-azure:
        error: 'failed to find any provider resources affiliated with template: cluster-api-provider-azure'
      hmc:
        success: true
      k0smotron:
        success: true
```

In this case `cluster-api-provider-aws` is reporting some status conditions false:

```
  status:
    availableProviders: {}
    components:
      cluster-api:
        success: true
      cluster-api-provider-aws:
        error: 'InfrastructureProvider: aws is not yet ready, has false conditions: MinimumReplicasAvailable'
      cluster-api-provider-azure:
        success: true
      hmc:
        success: true
      k0smotron:
        success: true
```

In this case `cluster-api-provider-aws` has no `status.conditions` because something is going wrong.  Perhaps we could add some additional statuses for special circumstances; here it's because `aws-variables` does not yet exist yet, but I couldn't find anyway to assume this type of circumstance, capi-operator doesn't produce any event in this case, it only generates a log.

```
    components:
      cluster-api:
        success: true
      cluster-api-provider-aws:
        error: 'failed to get status for template: cluster-api-provider-aws: failed
          to get conditions: no status conditions found for InfrastructureProvider:
          aws'
      cluster-api-provider-azure:
        success: true
      hmc:
        success: true
      k0smotron:
        success: true
```

Closes #235 