### PR TITLE
Fix `make awscli` on darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -464,15 +464,18 @@ $(ENVSUBST): | $(LOCALBIN)
 .PHONY: awscli
 awscli: $(AWSCLI)
 $(AWSCLI): | $(LOCALBIN)
-	@if [ $(OS) == "linux" ]; then \
+	set -x; \
+	if [ $(OS) == "linux" ]; then \
 		curl "https://awscli.amazonaws.com/awscli-exe-linux-$(shell uname -m)-$(AWSCLI_VERSION).zip" -o "/tmp/awscliv2.zip"; \
 		unzip -qq /tmp/awscliv2.zip -d /tmp; \
 		/tmp/aws/install -i $(LOCALBIN)/aws-cli -b $(LOCALBIN) --update; \
 	fi; \
 	if [ $(OS) == "darwin" ]; then \
 			curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"; \
-			installer -pkg AWSCLIV2.pkg -target $(LOCALBIN) -applyChoiceChangesXML choices.xml; \
-			rm AWSCLIV2.pkg; \
+			LOCALBIN="$(LOCALBIN)" $(ENVSUBST) -i ./scripts/awscli-darwin-install.xml.tpl > choices.xml; \
+			sudo installer -pkg AWSCLIV2.pkg -target $(LOCALBIN) -applyChoiceChangesXML ./choices.xml; \
+			ln -s $(LOCALBIN)/aws-cli/aws $(LOCALBIN)/aws; \
+			rm AWSCLIV2.pkg && rm ./choices.xml; \
 	fi; \
 	if [ $(OS) == "windows" ]; then \
 		echo "Installing to $(LOCALBIN) on Windows is not yet implemented"; \

--- a/scripts/awscli-darwin-install.xml.tpl
+++ b/scripts/awscli-darwin-install.xml.tpl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <dict>
+      <key>choiceAttribute</key>
+      <string>customLocation</string>
+      <key>attributeSetting</key>
+      <string>${LOCALBIN}</string>
+      <key>choiceIdentifier</key>
+      <string>default</string>
+    </dict>
+  </array>
+</plist>


### PR DESCRIPTION
Unfortunately using `installer` on MacOS requires `sudo` even though it's installing into `$LOCALBIN`, but this works for now.  There doesn't seem to be any other way to get the binary into `$LOCALBIN` other then getting other dependencies like `pip` or `brew` involved. An annoying one for sure.

Closes: #365 