### PR TITLE
Restore missing session token variable for aws credentials

### DIFF
--- a/config/dev/aws-credentials.yaml
+++ b/config/dev/aws-credentials.yaml
@@ -19,3 +19,4 @@ type: Opaque
 stringData:
   AccessKeyID: ${AWS_ACCESS_KEY_ID}
   SecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
+  SessionToken: ${AWS_SESSION_TOKEN}


### PR DESCRIPTION
Simple fix to restore the AWS_SESSION_TOKEN functionality for aws credentials.