### PR TITLE
Handle TemplateManagement creation and removal

### DIFF
--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -25,6 +25,7 @@ const (
 
 	CoreCAPIName = "capi"
 
+	ManagementKind         = "Management"
 	ManagementName         = "hmc"
 	ManagementFinalizer    = "hmc.mirantis.com/management"
 	TemplateManagementName = "hmc"

--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -25,8 +25,9 @@ const (
 
 	CoreCAPIName = "capi"
 
-	ManagementName      = "hmc"
-	ManagementFinalizer = "hmc.mirantis.com/management"
+	ManagementName         = "hmc"
+	ManagementFinalizer    = "hmc.mirantis.com/management"
+	TemplateManagementName = "hmc"
 )
 
 // ManagementSpec defines the desired state of Management

--- a/api/v1alpha1/templatemanagement_types.go
+++ b/api/v1alpha1/templatemanagement_types.go
@@ -18,6 +18,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const TemplateManagementKind = "TemplateManagement"
+
 // TemplateManagementSpec defines the desired state of TemplateManagement
 type TemplateManagementSpec struct {
 	// AccessRules is the list of access rules. Each AccessRule enforces

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -67,6 +67,7 @@ func main() {
 		insecureRegistry          bool
 		registryCredentialsSecret string
 		createManagement          bool
+		createTemplateManagement  bool
 		createTemplates           bool
 		hmcTemplatesChartName     string
 		enableTelemetry           bool
@@ -87,6 +88,8 @@ func main() {
 		"Secret containing authentication credentials for the registry.")
 	flag.BoolVar(&insecureRegistry, "insecure-registry", false, "Allow connecting to an HTTP registry.")
 	flag.BoolVar(&createManagement, "create-management", true, "Create Management object with default configuration.")
+	flag.BoolVar(&createTemplateManagement, "create-template-management", true,
+		"Create TemplateManagement object with default configuration.")
 	flag.BoolVar(&createTemplates, "create-templates", true, "Create HMC Templates.")
 	flag.StringVar(&hmcTemplatesChartName, "hmc-templates-chart-name", "hmc-templates",
 		"The name of the helm chart with HMC Templates.")
@@ -232,12 +235,13 @@ func main() {
 		os.Exit(1)
 	}
 	if err = mgr.Add(&controller.Poller{
-		Client:                mgr.GetClient(),
-		Config:                mgr.GetConfig(),
-		CreateManagement:      createManagement,
-		CreateTemplates:       createTemplates,
-		HMCTemplatesChartName: hmcTemplatesChartName,
-		SystemNamespace:       currentNamespace,
+		Client:                   mgr.GetClient(),
+		Config:                   mgr.GetConfig(),
+		CreateManagement:         createManagement,
+		CreateTemplateManagement: createTemplateManagement,
+		CreateTemplates:          createTemplates,
+		HMCTemplatesChartName:    hmcTemplatesChartName,
+		SystemNamespace:          currentNamespace,
 	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ReleaseController")
 		os.Exit(1)

--- a/internal/controller/templatemanagement_controller_test.go
+++ b/internal/controller/templatemanagement_controller_test.go
@@ -198,14 +198,8 @@ var _ = Describe("Template Management Controller", func() {
 				Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 			}
 
-			tm := &hmcmirantiscomv1alpha1.TemplateManagement{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: tmName}, tm)
-			Expect(err).NotTo(HaveOccurred())
-			By("Cleanup the specific resource instance TemplateManagement")
-			Expect(k8sClient.Delete(ctx, tm)).To(Succeed())
-
 			ctChain := &hmcmirantiscomv1alpha1.ClusterTemplateChain{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: ctChainName}, ctChain)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: ctChainName}, ctChain)
 			Expect(err).NotTo(HaveOccurred())
 			By("Cleanup the specific resource instance ClusterTemplateChain")
 			Expect(k8sClient.Delete(ctx, ctChain)).To(Succeed())

--- a/internal/webhook/templatemanagement_webhook.go
+++ b/internal/webhook/templatemanagement_webhook.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,7 +52,16 @@ var (
 )
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*TemplateManagementValidator) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (v *TemplateManagementValidator) ValidateCreate(ctx context.Context, _ runtime.Object) (admission.Warnings, error) {
+	itemsList := &v1.PartialObjectMetadataList{}
+	gvk := v1alpha1.GroupVersion.WithKind(v1alpha1.TemplateManagementKind)
+	itemsList.SetGroupVersionKind(gvk)
+	if err := v.List(ctx, itemsList); err != nil {
+		return nil, err
+	}
+	if len(itemsList.Items) > 0 {
+		return nil, fmt.Errorf("TemplateManagement object already exists")
+	}
 	return nil, nil
 }
 

--- a/internal/webhook/templatemanagement_webhook_test.go
+++ b/internal/webhook/templatemanagement_webhook_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Mirantis/hmc/api/v1alpha1"
 	"github.com/Mirantis/hmc/internal/utils"
 	"github.com/Mirantis/hmc/test/objects/managedcluster"
+	"github.com/Mirantis/hmc/test/objects/management"
 	"github.com/Mirantis/hmc/test/objects/template"
 	chain "github.com/Mirantis/hmc/test/objects/templatechain"
 	tm "github.com/Mirantis/hmc/test/objects/templatemanagement"
@@ -239,6 +240,63 @@ func TestTemplateManagementValidateUpdate(t *testing.T) {
 				Build()
 			validator := &TemplateManagementValidator{Client: c, SystemNamespace: utils.DefaultSystemNamespace}
 			warn, err := validator.ValidateUpdate(ctx, tm.NewTemplateManagement(), tt.newTm)
+			if tt.err != "" {
+				g.Expect(err).To(HaveOccurred())
+				if err.Error() != tt.err {
+					t.Fatalf("expected error '%s', got error: %s", tt.err, err.Error())
+				}
+			} else {
+				g.Expect(err).To(Succeed())
+			}
+			if len(tt.warnings) > 0 {
+				g.Expect(warn).To(Equal(tt.warnings))
+			} else {
+				g.Expect(warn).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestTemplateManagementValidateDelete(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := context.Background()
+
+	tmName := "test"
+
+	tests := []struct {
+		name            string
+		tm              *v1alpha1.TemplateManagement
+		existingObjects []runtime.Object
+		err             string
+		warnings        admission.Warnings
+	}{
+		{
+			name:            "should fail if Management object exists and was not deleted",
+			tm:              tm.NewTemplateManagement(tm.WithName(tmName)),
+			existingObjects: []runtime.Object{management.NewManagement()},
+			err:             "TemplateManagement deletion is forbidden",
+		},
+		{
+			name: "should succeed if Management object is not found",
+			tm:   tm.NewTemplateManagement(tm.WithName(tmName)),
+		},
+		{
+			name:            "should succeed if Management object was deleted",
+			tm:              tm.NewTemplateManagement(tm.WithName(tmName)),
+			existingObjects: []runtime.Object{management.NewManagement(management.WithDeletionTimestamp(metav1.Now()))},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithRuntimeObjects(tt.existingObjects...).
+				WithIndex(&v1alpha1.ManagedCluster{}, v1alpha1.TemplateKey, v1alpha1.ExtractTemplateName).
+				Build()
+			validator := &TemplateManagementValidator{Client: c, SystemNamespace: utils.DefaultSystemNamespace}
+			warn, err := validator.ValidateDelete(ctx, tt.tm)
 			if tt.err != "" {
 				g.Expect(err).To(HaveOccurred())
 				if err.Error() != tt.err {

--- a/templates/provider/hmc/templates/deployment.yaml
+++ b/templates/provider/hmc/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         - --registry-creds-secret={{ .Values.controller.registryCredsSecret }}
         {{- end }}
         - --create-management={{ .Values.controller.createManagement }}
+        - --create-template-management={{ .Values.controller.createTemplateManagement }}
         - --create-templates={{ .Values.controller.createTemplates }}
         - --enable-telemetry={{ .Values.controller.enableTelemetry }}
         - --enable-webhook={{ .Values.admissionWebhook.enabled }}

--- a/templates/provider/hmc/templates/rbac/controller/roles.yaml
+++ b/templates/provider/hmc/templates/rbac/controller/roles.yaml
@@ -43,12 +43,7 @@ rules:
   - hmc.mirantis.com
   resources:
   - templatemanagements
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  verbs: {{ include "rbac.editorVerbs" . | nindent 4 }}
 - apiGroups:
   - hmc.mirantis.com
   resources:

--- a/templates/provider/hmc/values.schema.json
+++ b/templates/provider/hmc/values.schema.json
@@ -116,6 +116,9 @@
         "createManagement": {
           "type": "boolean"
         },
+        "createTemplateManagement": {
+          "type": "boolean"
+        },
         "createTemplate": {
           "type": "boolean"
         },

--- a/templates/provider/hmc/values.yaml
+++ b/templates/provider/hmc/values.yaml
@@ -11,6 +11,7 @@ controller:
   registryCredsSecret: ""
   insecureRegistry: false
   createManagement: true
+  createTemplateManagement: true
   createTemplates: true
   enableTelemetry: true
 

--- a/test/objects/management/management.go
+++ b/test/objects/management/management.go
@@ -29,7 +29,8 @@ type Opt func(management *v1alpha1.Management)
 func NewManagement(opts ...Opt) *v1alpha1.Management {
 	p := &v1alpha1.Management{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: DefaultName,
+			Name:       DefaultName,
+			Finalizers: []string{v1alpha1.ManagementFinalizer},
 		},
 	}
 
@@ -42,6 +43,12 @@ func NewManagement(opts ...Opt) *v1alpha1.Management {
 func WithName(name string) Opt {
 	return func(p *v1alpha1.Management) {
 		p.Name = name
+	}
+}
+
+func WithDeletionTimestamp(deletionTimestamp metav1.Time) Opt {
+	return func(p *v1alpha1.Management) {
+		p.DeletionTimestamp = &deletionTimestamp
 	}
 }
 


### PR DESCRIPTION
1. Support automatically creating the `TemplateManagement` with no access rules (enabled by default).
2. Forbid the creation of more than one `TemplateManagement` object.
3. Forbid the removal of the `TemplateManagement` object if the Management object exists and was not triggered for the deletion.

Closes #373