### PR TITLE
Add `Credential` to dev config for AWS

### DIFF
--- a/config/dev/aws-credentials.yaml
+++ b/config/dev/aws-credentials.yaml
@@ -20,3 +20,15 @@ stringData:
   AccessKeyID: ${AWS_ACCESS_KEY_ID}
   SecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
   SessionToken: ${AWS_SESSION_TOKEN}
+---
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: Credential
+metadata:
+  name: aws-cluster-identity-cred
+  namespace: ${NAMESPACE}
+spec:
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: AWSClusterStaticIdentity
+    name: aws-cluster-identity
+    namespace: ${NAMESPACE}

--- a/config/dev/aws-managedcluster.yaml
+++ b/config/dev/aws-managedcluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: aws-dev
   namespace: ${NAMESPACE}
 spec:
+  credential: aws-cluster-identity-cred
   config:
     clusterIdentity:
       name: aws-cluster-identity

--- a/config/dev/azure-credentials.yaml
+++ b/config/dev/azure-credentials.yaml
@@ -23,3 +23,15 @@ metadata:
 stringData:
   clientSecret: "${AZURE_CLIENT_SECRET}"
 type: Opaque
+---
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: Credential
+metadata:
+  name: azure-cluster-identity-cred
+  namespace: ${NAMESPACE}
+spec:
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: azure-cluster-identity
+    namespace: ${NAMESPACE}

--- a/config/dev/azure-managedcluster.yaml
+++ b/config/dev/azure-managedcluster.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   template: azure-standalone-cp
+  credential: azure-cluster-identity-cred
   config:
     controlPlaneNumber: 1
     workersNumber: 1

--- a/config/dev/vsphere-credentials.yaml
+++ b/config/dev/vsphere-credentials.yaml
@@ -18,3 +18,15 @@ metadata:
 stringData:
   username: ${VSPHERE_USER}
   password: ${VSPHERE_PASSWORD}
+---
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: Credential
+metadata:
+  name: vsphere-cluster-identity-cred
+  namespace: ${NAMESPACE}
+spec:
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: VSphereClusterIdentity
+    name: vsphere-cluster-identity
+    namespace: ${NAMESPACE}

--- a/config/dev/vsphere-managedcluster.yaml
+++ b/config/dev/vsphere-managedcluster.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   template: vsphere-standalone-cp
+  credential: vsphere-cluster-identity-cred
   config:
     controlPlaneNumber: 1
     workersNumber: 1


### PR DESCRIPTION
Adding `Credential` to the YAML files for AWS under `dev/config`.  This is needed after https://github.com/Mirantis/hmc/pull/342 was merged. Without this the HMC Operator keeps on failing with:
```sh
ster", "ManagedCluster": {"name":"wali-aws-dev","namespace":"hmc-system"}, "namespace": "hmc-system", "name": "wali-aws-dev", "reconcileID": "de457532-16dd-466a-afe0-e8c5d410ecf4", "error": "Credential.hmc.mirantis.com \"\" not found"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224
```