### PR TITLE
Add validation for ServiceTemplateChain

### DIFF
--- a/internal/webhook/template_webhook_test.go
+++ b/internal/webhook/template_webhook_test.go
@@ -142,7 +142,12 @@ func TestServiceTemplateValidateDelete(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			g := NewWithT(t)
 
-			c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.existingObjects...).Build()
+			c := fake.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithRuntimeObjects(tt.existingObjects...).
+				WithIndex(tt.existingObjects[0], v1alpha1.ServicesTemplateKey, v1alpha1.ExtractServiceTemplateName).
+				Build()
 			validator := &ServiceTemplateValidator{Client: c}
 			warn, err := validator.ValidateDelete(ctx, tt.template)
 			if tt.err != "" {

--- a/test/objects/managedcluster/managedcluster.go
+++ b/test/objects/managedcluster/managedcluster.go
@@ -73,3 +73,11 @@ func WithConfig(config string) Opt {
 		}
 	}
 }
+
+func WithServiceTemplate(templateName string) Opt {
+	return func(p *v1alpha1.ManagedCluster) {
+		p.Spec.Services = append(p.Spec.Services, v1alpha1.ManagedClusterServiceSpec{
+			Template: templateName,
+		})
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Mirantis/hmc/issues/316.

Originally I wrote the create validation for [Cluster/Service]TemplateChain to check if the templates being referenced in `.Spec.SupportedTemplates` actually existed in the same namespace. However, looking at how https://github.com/Mirantis/hmc/pull/407 has been implemented I dumped that so there is no validation check happening for create now.