### PR TITLE
Bump vsphere-csi-driver to 0.0.2

### DIFF
--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -62,7 +62,7 @@ spec:
                     operator: Exists
           - name: vsphere-csi
             chartname: mirantis/vsphere-csi-driver
-            version: 0.0.1
+            version: 0.0.2
             order: 2
             namespace: kube-system
             values: |

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -96,7 +96,7 @@ spec:
                       operator: Exists
             - name: vsphere-csi
               chartname: mirantis/vsphere-csi-driver
-              version: 0.0.1
+              version: 0.0.2
               order: 3
               namespace: kube-system
               values: |

--- a/templates/provider/hmc-templates/files/templates/vsphere-hosted-cp.yaml
+++ b/templates/provider/hmc-templates/files/templates/vsphere-hosted-cp.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   helm:
     chartName: vsphere-hosted-cp
-    chartVersion: 0.0.1
+    chartVersion: 0.0.2

--- a/templates/provider/hmc-templates/files/templates/vsphere-standalone-cp.yaml
+++ b/templates/provider/hmc-templates/files/templates/vsphere-standalone-cp.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   helm:
     chartName: vsphere-standalone-cp
-    chartVersion: 0.0.1
+    chartVersion: 0.0.2


### PR DESCRIPTION
Pulls in fix for default repo from https://github.com/Mirantis/helm-charts/pull/1