### PR TITLE
Add Webhooks for ServiceTemplate to ValidatingWebhookConfiguration

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -97,10 +97,10 @@ func ExtractServiceTemplateName(rawObj client.Object) []string {
 		return nil
 	}
 
-	services := []string{}
+	templates := []string{}
 	for _, s := range cluster.Spec.Services {
-		services = append(services, s.Template)
+		templates = append(templates, s.Template)
 	}
 
-	return services
+	return templates
 }

--- a/internal/webhook/template_webhook.go
+++ b/internal/webhook/template_webhook.go
@@ -94,12 +94,12 @@ type ServiceTemplateValidator struct {
 	client.Client
 }
 
-func (in *ServiceTemplateValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	in.Client = mgr.GetClient()
+func (v *ServiceTemplateValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	v.Client = mgr.GetClient()
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&v1alpha1.ServiceTemplate{}).
-		WithValidator(in).
-		WithDefaulter(in).
+		WithValidator(v).
+		WithDefaulter(v).
 		Complete()
 }
 
@@ -119,20 +119,18 @@ func (*ServiceTemplateValidator) ValidateUpdate(_ context.Context, _ runtime.Obj
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (in *ServiceTemplateValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (v *ServiceTemplateValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	tmpl, ok := obj.(*v1alpha1.ServiceTemplate)
 	if !ok {
 		return admission.Warnings{"Wrong object"}, apierrors.NewBadRequest(fmt.Sprintf("expected ServiceTemplate but got a %T", obj))
 	}
 
 	managedClusters := &v1alpha1.ManagedClusterList{}
-	listOptions := client.ListOptions{
+	if err := v.Client.List(ctx, managedClusters, &client.ListOptions{
 		FieldSelector: fields.SelectorFromSet(fields.Set{v1alpha1.ServicesTemplateKey: tmpl.Name}),
 		Limit:         1,
 		Namespace:     tmpl.Namespace,
-	}
-	err := in.Client.List(ctx, managedClusters, &listOptions)
-	if err != nil {
+	}); err != nil {
 		return nil, err
 	}
 
@@ -152,12 +150,12 @@ type ProviderTemplateValidator struct {
 	client.Client
 }
 
-func (in *ProviderTemplateValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	in.Client = mgr.GetClient()
+func (v *ProviderTemplateValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	v.Client = mgr.GetClient()
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&v1alpha1.ProviderTemplate{}).
-		WithValidator(in).
-		WithDefaulter(in).
+		WithValidator(v).
+		WithDefaulter(v).
 		Complete()
 }
 

--- a/templates/provider/hmc/templates/webhooks.yaml
+++ b/templates/provider/hmc/templates/webhooks.yaml
@@ -121,11 +121,30 @@ webhooks:
         apiVersions:
           - v1alpha1
         operations:
-          - CREATE
-          - UPDATE
           - DELETE
         resources:
           - clustertemplates
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: {{ include "hmc.webhook.serviceName" . }}
+        namespace: {{ include "hmc.webhook.serviceNamespace" . }}
+        path: /validate-hmc-mirantis-com-v1alpha1-servicetemplate
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: validation.servicetemplate.hmc.mirantis.com
+    rules:
+      - apiGroups:
+          - hmc.mirantis.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - DELETE
+        resources:
+          - servicetemplates
     sideEffects: None
   - admissionReviewVersions:
       - v1


### PR DESCRIPTION
Missed adding this to https://github.com/Mirantis/hmc/pull/416.
Deletes on `ServiceTemplate` now blocked if it is referenced in a `ManagedCluster` object:
```sh
➜  ~ khmc delete servicetemplate ingress-nginx 
Warning: The ServiceTemplate object can't be removed if ManagedCluster objects referencing it still exist
Error from server (Forbidden): admission webhook "validation.servicetemplate.hmc.mirantis.com" denied the request: template deletion is forbidden
```