### PR TITLE
Fix bug introduced in Sveltos install

### DIFF
--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -332,7 +332,7 @@ func wrappedComponents(mgmt *hmc.Management, release *hmc.Release) ([]component,
 			c.Template = release.ProviderTemplate(p.Name)
 		}
 
-		if c.Template == hmc.ProviderSveltosName {
+		if p.Name == hmc.ProviderSveltosName {
 			c.targetNamespace = hmc.ProviderSveltosTargetNamespace
 			c.createNamespace = hmc.ProviderSveltosCreateNamespace
 		}


### PR DESCRIPTION
# Description
Small fix without which Sveltos will not install because the template names now have versions appended to them. See https://github.com/Mirantis/hmc/pull/436.

# Testing
HMC can install Sveltos now:
```sh
➜  ~ kubectl -n hmc-system get helmreleases.helm.toolkit.fluxcd.io projectsveltos 
NAME             AGE     READY   STATUS
projectsveltos   3m34s   True    Helm install succeeded for release projectsveltos/projectsveltos.v1 with chart projectsveltos@0.38.2
➜  ~ 
➜  ~ kubectl -n projectsveltos get deployment
NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
access-manager          1/1     1            1           2m54s
addon-controller        1/1     1            1           2m54s
classifier-manager      1/1     1            1           2m54s
conversion-webhook      1/1     1            1           2m54s
event-manager           1/1     1            1           2m54s
hc-manager              1/1     1            1           2m54s
sc-manager              1/1     1            1           2m54s
shard-controller        1/1     1            1           2m54s
sveltos-agent-manager   1/1     1            1           2m1s
```