### PR TITLE
Honor the createRelease flag when reconciling

### DIFF
--- a/config/dev/hmc_values.yaml
+++ b/config/dev/hmc_values.yaml
@@ -4,5 +4,5 @@ image:
 controller:
   defaultRegistryURL: oci://hmc-local-registry:5000/charts
   insecureRegistry: true
-  createRelease: false
+  createRelease: true
   createTemplates: false

--- a/internal/utils/release.go
+++ b/internal/utils/release.go
@@ -20,6 +20,15 @@ func ReleaseNameFromVersion(version string) string {
 	return "hmc-" + strings.ReplaceAll(strings.TrimPrefix(version, "v"), ".", "-")
 }
 
+func ChartVersionFromVersion(version string) string {
+	index := strings.Index(version, "-")
+	cut := strings.TrimPrefix(version, "v")
+	if index >= 1 {
+		cut = cut[:index-1]
+	}
+	return cut
+}
+
 func TemplatesChartFromReleaseName(releaseName string) string {
 	return releaseName + "-tpl"
 }


### PR DESCRIPTION
Small change to use the createRelease flag and not create the release if the flag is false.