### PR TITLE
Fix -  Initial version of hmc-templates release gets updated concurrently 

### DIFF
--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -252,7 +252,7 @@ func (r *ReleaseReconciler) reconcileHMCTemplates(ctx context.Context, releaseNa
 		},
 	}
 
-	if releaseName == "" {
+	if releaseName == "" || r.CreateRelease {
 		createReleaseValues := map[string]any{
 			"createRelease": true,
 		}


### PR DESCRIPTION
Simple change to resolve #449. 

Testing performed:
1. Updated hmc_values.yaml to set the createRelease flag to true
2. Executed `make hmc-chart-release`
3. Ran `make kind-deploy registry-deploy dev-push dev-deploy dev-templates` (make dev-apply without the dev-release target)
4. Verified the release was created correctly

1. Updated hmc_values.yml to set the createRelease flag to false
2. Ran `make kind-deploy registry-deploy dev-push dev-deploy dev-templates` (make dev-apply without the dev-release target)
3. Verified the release was not created and there was no loop attempting to create it
4. ran `make dev-release` and verified the release was installed correctly

Also ran `make dev-apply` with the createRelease flag set to false (clean version of hmc_values.yaml) and verified this works as well.