### PR TITLE
Strip leading v from VERSION in 'Get outputs' job

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Get outputs
         id: vars
         run: |
-          echo "version=$(git describe --tags --always)" >> $GITHUB_OUTPUT
+          GIT_VERSION=$(git describe --tags --always)
+          echo "version=${GIT_VERSION:1}" >> $GITHUB_OUTPUT
           echo "clustername=ci-$(date +%s | cut -b6-10)" >> $GITHUB_OUTPUT
       - name: Build and push HMC controller image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
The leading `v` was removed from `VERSION` in #505, but the test outputs get generated outside of the `Makefile`, this fixes the version used within the test workflow as well.  Unfortunately, with the nature of `pull_request_target` the CI won't pass until merged because this is a workflow file change (we really need to change this behavior when things cool down around here) 