### PR TITLE
Remove installBeachHeadServices from sample template

### DIFF
--- a/config/dev/aws-managedcluster.yaml
+++ b/config/dev/aws-managedcluster.yaml
@@ -17,7 +17,6 @@ spec:
     worker:
       instanceType: t3.small
     workersNumber: 1
-    installBeachHeadServices: false
   template: aws-standalone-cp-0-0-2
   servicesPriority: 100
   services:


### PR DESCRIPTION
Followup to https://github.com/Mirantis/hmc/pull/502. We don't need it anymore.