### PR TITLE
Get the PR ref from the merge commit within `pull_request_target` workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -30,10 +30,22 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.version }}
       clustername: ${{ steps.vars.outputs.clustername }}
+      pr: ${{ steps.pr.outputs.result }}
     steps:
+      - name: Get PR ref
+        uses: actions/github-script@v6
+        id: pr
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            return pullRequest
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{fromJSON(steps.pr.outputs.result).merge_commit_sha}}
           fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -90,11 +102,13 @@ jobs:
     outputs:
       clustername: ${{ needs.build.outputs.clustername }}
       version: ${{ needs.build.outputs.version }}
+      pr: ${{ needs.build.outputs.pr }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
       - name: Run E2E tests
@@ -124,6 +138,7 @@ jobs:
     outputs:
       clustername: ${{ needs.build.outputs.clustername }}
       version: ${{ needs.build.outputs.version }}
+      pr: ${{ needs.build.outputs.pr }}
     env:
       AWS_REGION: us-west-2
       AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
@@ -138,6 +153,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -172,6 +188,7 @@ jobs:
     outputs:
       clustername: ${{ needs.build.outputs.clustername }}
       version: ${{ needs.build.outputs.version }}
+      pr: ${{ needs.build.outputs.pr }}
     env:
       VSPHERE_USER: ${{ secrets.CI_VSPHERE_USER }}
       VSPHERE_PASSWORD: ${{ secrets.CI_VSPHERE_PASSWORD }}
@@ -190,6 +207,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -220,11 +238,16 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && !contains(needs.provider-cloud-e2etest.result, 'skipped') && contains(needs.build.result, 'success') }}
     timeout-minutes: 15
+    outputs:
+      clustername: ${{ needs.build.outputs.clustername }}
+      version: ${{ needs.build.outputs.version }}
+      pr: ${{ needs.build.outputs.pr }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
With our change to `pull_request_target` for workflow runs, `actions/checkout` needs to be updated to grab the ref from the PR, not from where the job is running.  This is because `pull_request_target` runs on the target branch.

This PR uses the GitHub API to fetch the merge commit sha and use that as the ref for `actions/checkout`
