### PR TITLE
Update release actions with airgap bundle upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,17 @@ jobs:
             dist/install.yaml
             templates/provider/hmc-templates/files/release.yaml
           draft: true
+
+      - name: Build airgap bundle
+        env:
+          IMG: 'ghcr.io/mirantis/hmc:${{ env.VERSION }}'
+        run: |
+          make airgap-package
+
+      - name: Upload airgap bundle
+        env:
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+        run: |
+          make awscli
+          ./bin/aws s3 cp bin/hmc-airgap-${{ env.VERSION }}.tgz s3://binary2a-mirantis-com.s3.amazonaws.com/hmc-airgap-${{ env.VERSION }}.tgz


### PR DESCRIPTION
This updates our release action with two steps which create the airgap package tarball and then upload it to our binary2a.mirantis.com S3 bucket.

Note that this action will not work until the secrets affiliated with the S3 are populated in the GitHub secrets store.  @DinaBelova or @Kshatrix should work with Roman Vyalov to populate those secrets since today is my last day at Mirantis.

I don't have a way to test this since I don't have access to the s3 bucket, but I figured writing a starting point would be helpful for someone to carry.