### PR TITLE
Use linter from makefile target in the build workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -53,9 +53,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          args: --timeout 10m0s
+        run: GOLANGCI_LINT_TIMEOUT=10m make lint
       - name: Verify all generated pieces are up-to-date
         run: make generate-all && git add -N . && git diff --exit-code
       - name: Unit tests

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ test-e2e: cli-install
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint
-	@$(GOLANGCI_LINT) run
+	@$(GOLANGCI_LINT) run --timeout=$(GOLANGCI_LINT_TIMEOUT)
 
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
@@ -429,6 +429,7 @@ AWSCLI ?= $(LOCALBIN)/aws
 CONTROLLER_TOOLS_VERSION ?= v0.16.3
 ENVTEST_VERSION ?= release-0.17
 GOLANGCI_LINT_VERSION ?= v1.61.0
+GOLANGCI_LINT_TIMEOUT ?= 1m
 HELM_VERSION ?= v3.15.1
 KIND_VERSION ?= v0.23.0
 YQ_VERSION ?= v4.44.2


### PR DESCRIPTION
By default, the `golangci/golangci-lint-action` uses the latest linter version (currently v1.62.0). With the linter of v1.62.0 version, the `max-public-structs` linter shows a false-positive result.

Currently, in our Makefile, we have the linter version pinned to `v1.61.0`. This PR ensures consistency by aligning the linter version in the GitHub Actions workflow with the version used in the Makefile (which is used locally).

Closes #624 
