### PR TITLE
Pin linter version to v1.61.0 in the build workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -55,7 +55,9 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
+          version: v1.61.0
           args: --timeout 10m0s
+          skip-cache: true
       - name: Verify all generated pieces are up-to-date
         run: make generate-all && git add -N . && git diff --exit-code
       - name: Unit tests


### PR DESCRIPTION
By default, the linter uses the latest version, which is currently v1.62.0. In v1.62.0, a new `max-public-structs` linter was added. Significant changes are required in our codebase to enable this linter.

This PR also aligns the linter version with the one specified in the Makefile target.