### PR TITLE
Pass pvt repo creds to Sveltos & make services reconcile independent

### DIFF
--- a/config/dev/aws-managedcluster.yaml
+++ b/config/dev/aws-managedcluster.yaml
@@ -1,17 +1,30 @@
 apiVersion: hmc.mirantis.com/v1alpha1
 kind: ManagedCluster
 metadata:
-  name: aws-dev
-  namespace: ${NAMESPACE}
+  name: wali-aws-dev
+  namespace: hmc-system
 spec:
   template: aws-standalone-cp-0-0-3
   credential: aws-cluster-identity-cred
   config:
+    clusterIdentity:
+      name: aws-cluster-identity
+      namespace: hmc-system
     controlPlane:
+      amiID: ami-0eb9fdcf0d07bd5ef
       instanceType: t3.small
     controlPlaneNumber: 1
-    publicIP: false
-    region: ${AWS_REGION}
+    publicIP: true
+    region: ca-central-1
     worker:
+      amiID: ami-0eb9fdcf0d07bd5ef
       instanceType: t3.small
     workersNumber: 1
+  credential: aws-cluster-identity-cred
+  services:
+    - template: kyverno-3-2-6
+      name: kyverno
+      namespace: kyverno
+  servicesPriority: 1000
+  stopOnConflict: false
+  template: aws-standalone-cp-0-0-2

--- a/config/dev/aws-managedcluster.yaml
+++ b/config/dev/aws-managedcluster.yaml
@@ -1,30 +1,17 @@
 apiVersion: hmc.mirantis.com/v1alpha1
 kind: ManagedCluster
 metadata:
-  name: wali-aws-dev
-  namespace: hmc-system
+  name: aws-dev
+  namespace: ${NAMESPACE}
 spec:
   template: aws-standalone-cp-0-0-3
   credential: aws-cluster-identity-cred
   config:
-    clusterIdentity:
-      name: aws-cluster-identity
-      namespace: hmc-system
     controlPlane:
-      amiID: ami-0eb9fdcf0d07bd5ef
       instanceType: t3.small
     controlPlaneNumber: 1
-    publicIP: true
-    region: ca-central-1
+    publicIP: false
+    region: ${AWS_REGION}
     worker:
-      amiID: ami-0eb9fdcf0d07bd5ef
       instanceType: t3.small
     workersNumber: 1
-  credential: aws-cluster-identity-cred
-  services:
-    - template: kyverno-3-2-6
-      name: kyverno
-      namespace: kyverno
-  servicesPriority: 1000
-  stopOnConflict: false
-  template: aws-standalone-cp-0-0-2

--- a/internal/controller/managedcluster_controller.go
+++ b/internal/controller/managedcluster_controller.go
@@ -189,7 +189,7 @@ func (r *ManagedClusterReconciler) reconcileUpdate(ctx context.Context, mc *hmc.
 	return ctrl.Result{}, nil
 }
 
-func (r *ManagedClusterReconciler) updateCluster(ctx context.Context, mc *hmc.ManagedCluster, clusterTpl *hmc.ClusterTemplate) (result ctrl.Result, err error) {
+func (r *ManagedClusterReconciler) updateCluster(ctx context.Context, mc *hmc.ManagedCluster, clusterTpl *hmc.ClusterTemplate) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx)
 
 	if clusterTpl == nil {

--- a/internal/sveltos/profile.go
+++ b/internal/sveltos/profile.go
@@ -69,7 +69,7 @@ func ReconcileClusterProfile(
 	}
 
 	operation, err := ctrl.CreateOrUpdate(ctx, cl, cp, func() error {
-		spec, err := Spec(&opts)
+		spec, err := GetSpec(&opts)
 		if err != nil {
 			return err
 		}
@@ -106,7 +106,7 @@ func ReconcileProfile(
 	}
 
 	operation, err := ctrl.CreateOrUpdate(ctx, cl, p, func() error {
-		spec, err := Spec(&opts)
+		spec, err := GetSpec(&opts)
 		if err != nil {
 			return err
 		}
@@ -218,9 +218,9 @@ func GetHelmChartOpts(ctx context.Context, c client.Client, namespace string, se
 	return opts, nil
 }
 
-// Spec returns a spec object to be used with
+// GetSpec returns a spec object to be used with
 // a Sveltos Profile or ClusterProfile object.
-func Spec(opts *ReconcileProfileOpts) (*sveltosv1beta1.Spec, error) {
+func GetSpec(opts *ReconcileProfileOpts) (*sveltosv1beta1.Spec, error) {
 	tier, err := priorityToTier(opts.Priority)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

1. Pass private repository credentials to Sveltos objects ([#625](https://github.com/Mirantis/hmc/issues/625)).
2. Do not return without reconciling services even if reconciling cluster fails ([#640](https://github.com/Mirantis/hmc/issues/640)).

# Testing

## Testing Private Repository
I created the following `myappz-0-4-0` serviceTemplate which references a chart in `oci://registry-1.docker.io/wali90` private repository:
```yaml
apiVersion: v1
kind: Secret
data:
  .dockerconfigjson: # redacted base64 string of {"auths":{"https://registry-1.docker.io/wali90":{"username":"?","password":"?","auth":"<base64 of user:pass>"}}}
metadata:
  name: dockerhub-creds-dockerconfig-oci
  namespace: hmc-system
type: kubernetes.io/dockerconfigjson
---
apiVersion: source.toolkit.fluxcd.io/v1
kind: HelmRepository
metadata:
  labels:
    hmc.mirantis.com/managed: "true"
  name: myappz
  namespace: hmc-system
spec:
  type: oci
  url: oci://registry-1.docker.io/wali90
  secretRef:
    name: dockerhub-creds-dockerconfig-oci
---
apiVersion: source.toolkit.fluxcd.io/v1
kind: HelmChart
metadata:
  labels:
    hmc.mirantis.com/managed: "true"
  name: myappz-0-4-0
  namespace: hmc-system
spec:
  chart: myappz
  interval: 10m0s
  sourceRef:
    kind: HelmRepository
    name: myappz
  version: 0.4.0
---
apiVersion: hmc.mirantis.com/v1alpha1
kind: ServiceTemplate
metadata:
  name: myappz-0-4-0
  namespace: hmc-system
spec:
  helm:
    chartRef:
      apiVersion: source.toolkit.fluxcd.io/v1
      kind: HelmChart
      name: myappz-0-4-0
      namespace: hmc-system
```
```sh
➜  ~ kubectl -n hmc-system get helmrepository myappz 
NAME     URL                                 AGE   READY   STATUS
myappz   oci://registry-1.docker.io/wali90   73s           
➜  ~ kubectl -n hmc-system get helmcharts myappz-0-4-0             
NAME           CHART    VERSION   SOURCE KIND      SOURCE NAME   AGE   READY   STATUS
myappz-0-4-0   myappz   0.4.0     HelmRepository   myappz        85s   True    pulled 'myappz' chart with version '0.4.0'
➜  ~ kubectl -n hmc-system get servicetemplate myappz-0-4-0 
NAME           VALID
myappz-0-4-0   true
```
As can bee seen (from status) that the MultiClusterService using the `myappz-0-4-0` ServiceTemplate has deployed the service successfully on to the target cluster:
```yaml
apiVersion: hmc.mirantis.com/v1alpha1
kind: MultiClusterService
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"hmc.mirantis.com/v1alpha1","kind":"MultiClusterService","metadata":{"annotations":{},"name":"myappz-global"},"spec":{"clusterSelector":{"matchLabels":{"app.kubernetes.io/managed-by":"Helm"}},"services":[{"name":"myappz","namespace":"myappz","template":"myappz-0-4-0"}],"servicesPriority":1000}}
  creationTimestamp: "2024-11-18T21:38:44Z"
  finalizers:
  - hmc.mirantis.com/multicluster-service
  generation: 1
  name: myappz-global
  resourceVersion: "19627"
  uid: 15d9f991-3b3f-447c-9af6-641d6a6a40a1
spec:
  clusterSelector:
    matchLabels:
      app.kubernetes.io/managed-by: Helm
  services:
  - name: myappz
    namespace: myappz
    template: myappz-0-4-0
  servicesPriority: 1000
  stopOnConflict: false
status:
  conditions:
  - lastTransitionTime: "2024-11-18T21:38:44Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: SveltosClusterProfileReady
  - lastTransitionTime: "2024-11-18T21:38:44Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: FetchServicesStatusSuccess
  - lastTransitionTime: "2024-11-18T21:38:44Z"
    message: MultiClusterService is ready
    reason: Succeeded
    status: "True"
    type: Ready
  observedGeneration: 1
  services:
  - clusterName: wali-aws-dev
    clusterNamespace: hmc-system
    conditions:
    - lastTransitionTime: "2024-11-18T21:38:44Z"
      message: ""
      reason: Provisioned
      status: "True"
      type: Helm
    - lastTransitionTime: "2024-11-18T21:38:44Z"
      message: Release myappz/myappz
      reason: Managing
      status: "True"
      type: myappz.myappz/SveltosHelmReleaseReady
```
## Testing Services Reconcile
I have a fresh instance of ManagedCluster with `kyverno-3-2-6` deployed
```yaml
apiVersion: hmc.mirantis.com/v1alpha1
kind: ManagedCluster
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"hmc.mirantis.com/v1alpha1","kind":"ManagedCluster","metadata":{"annotations":{},"name":"wali-aws-dev","namespace":"hmc-system"},"spec":{"config":{"clusterIdentity":{"name":"aws-cluster-identity","namespace":"hmc-system"},"controlPlane":{"amiID":"ami-0eb9fdcf0d07bd5ef","instanceType":"t3.small"},"controlPlaneNumber":1,"publicIP":true,"region":"ca-central-1","worker":{"amiID":"ami-0eb9fdcf0d07bd5ef","instanceType":"t3.small"},"workersNumber":1},"credential":"aws-cluster-identity-cred","services":[{"name":"kyverno","namespace":"kyverno","template":"kyverno-3-2-6"}],"servicesPriority":100,"stopOnConflict":false,"template":"aws-standalone-cp-0-0-3"}}
  creationTimestamp: "2024-11-19T07:17:13Z"
  finalizers:
  - hmc.mirantis.com/managed-cluster
  generation: 2
  name: wali-aws-dev
  namespace: hmc-system
  resourceVersion: "38017"
  uid: 4039815a-aa24-4677-a054-4f3904a3a023
spec:
  config:
    clusterIdentity:
      name: aws-cluster-identity
      namespace: hmc-system
    controlPlane:
      amiID: ami-0eb9fdcf0d07bd5ef
      instanceType: t3.small
    controlPlaneNumber: 1
    publicIP: true
    region: ca-central-1
    worker:
      amiID: ami-0eb9fdcf0d07bd5ef
      instanceType: t3.small
    workersNumber: 1
  credential: aws-cluster-identity-cred
  services:
  - name: kyverno
    namespace: kyverno
    template: kyverno-3-2-6
  servicesPriority: 100
  stopOnConflict: false
  template: aws-standalone-cp-0-0-3
status:
  conditions:
  - lastTransitionTime: "2024-11-19T07:17:13Z"
    message: Template is valid
    reason: Succeeded
    status: "True"
    type: TemplateReady
  - lastTransitionTime: "2024-11-19T07:17:13Z"
    message: Helm chart is valid
    reason: Succeeded
    status: "True"
    type: HelmChartReady
  - lastTransitionTime: "2024-11-19T07:17:14Z"
    message: Helm install succeeded for release hmc-system/wali-aws-dev.v1 with chart
      aws-standalone-cp@0.0.3
    reason: InstallSucceeded
    status: "True"
    type: HelmReleaseReady
  - lastTransitionTime: "2024-11-19T13:01:08Z"
    message: ManagedCluster is ready
    reason: Succeeded
    status: "True"
    type: Ready
  - lastTransitionTime: "2024-11-19T13:01:08Z"
    message: Credential is Ready
    reason: Succeeded
    status: "True"
    type: CredentialReady
  - lastTransitionTime: "2024-11-19T07:17:13Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: SveltosProfileReady
  - lastTransitionTime: "2024-11-19T07:17:13Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: FetchServicesStatusSuccess
  - lastTransitionTime: "2024-11-19T07:18:57Z"
    message: wali-aws-dev is Ready
    reason: Succeeded
    status: "True"
    type: ControlPlaneInitialized
  - lastTransitionTime: "2024-11-19T07:18:57Z"
    message: wali-aws-dev is Ready
    reason: Succeeded
    status: "True"
    type: ControlPlaneReady
  - lastTransitionTime: "2024-11-19T07:17:15Z"
    message: wali-aws-dev is Ready
    reason: Succeeded
    status: "True"
    type: InfrastructureReady
  - lastTransitionTime: "2024-11-19T07:20:44Z"
    message: wali-aws-dev-md is Ready
    reason: Succeeded
    status: "True"
    type: Available
  observedGeneration: 2
  services:
  - clusterName: wali-aws-dev
    clusterNamespace: hmc-system
    conditions:
    - lastTransitionTime: "2024-11-19T07:18:57Z"
      message: ""
      reason: Provisioned
      status: "True"
      type: Helm
    - lastTransitionTime: "2024-11-19T07:18:57Z"
      message: Release kyverno/kyverno
      reason: Managing
      status: "True"
      type: kyverno.kyverno/SveltosHelmReleaseReady
```
I induced failure by deleting the EC2 machines, so the status of ManagedCluster now shows failures. Then I also changed the spec to add another `ingress-nginx-4-11-3` service:
```yaml
apiVersion: hmc.mirantis.com/v1alpha1
kind: ManagedCluster
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"hmc.mirantis.com/v1alpha1","kind":"ManagedCluster","metadata":{"annotations":{},"name":"wali-aws-dev","namespace":"hmc-system"},"spec":{"config":{"clusterIdentity":{"name":"aws-cluster-identity","namespace":"hmc-system"},"controlPlane":{"amiID":"ami-0eb9fdcf0d07bd5ef","instanceType":"t3.small"},"controlPlaneNumber":1,"publicIP":true,"region":"ca-central-1","worker":{"amiID":"ami-0eb9fdcf0d07bd5ef","instanceType":"t3.small"},"workersNumber":1},"credential":"aws-cluster-identity-cred","services":[{"name":"kyverno","namespace":"kyverno","template":"kyverno-3-2-6"},{"name":"ingress-nginx","namespace":"ingress-nginx","template":"ingress-nginx-4-11-3"}],"servicesPriority":100,"stopOnConflict":false,"template":"aws-standalone-cp-0-0-3"}}
  creationTimestamp: "2024-11-19T07:17:13Z"
  finalizers:
  - hmc.mirantis.com/managed-cluster
  generation: 3
  name: wali-aws-dev
  namespace: hmc-system
  resourceVersion: "110918"
  uid: 4039815a-aa24-4677-a054-4f3904a3a023
spec:
  config:
    clusterIdentity:
      name: aws-cluster-identity
      namespace: hmc-system
    controlPlane:
      amiID: ami-0eb9fdcf0d07bd5ef
      instanceType: t3.small
    controlPlaneNumber: 1
    publicIP: true
    region: ca-central-1
    worker:
      amiID: ami-0eb9fdcf0d07bd5ef
      instanceType: t3.small
    workersNumber: 1
  credential: aws-cluster-identity-cred
  services:
  - name: kyverno
    namespace: kyverno
    template: kyverno-3-2-6
  - name: ingress-nginx
    namespace: ingress-nginx
    template: ingress-nginx-4-11-3
  servicesPriority: 100
  stopOnConflict: false
  template: aws-standalone-cp-0-0-3
status:
  conditions:
  - lastTransitionTime: "2024-11-19T07:17:13Z"
    message: Template is valid
    reason: Succeeded
    status: "True"
    type: TemplateReady
  - lastTransitionTime: "2024-11-19T07:17:13Z"
    message: Helm chart is valid
    reason: Succeeded
    status: "True"
    type: HelmChartReady
  - lastTransitionTime: "2024-11-19T07:17:14Z"
    message: Helm install succeeded for release hmc-system/wali-aws-dev.v1 with chart
      aws-standalone-cp@0.0.3
    reason: InstallSucceeded
    status: "True"
    type: HelmReleaseReady
  - lastTransitionTime: "2024-11-19T13:23:11Z"
    message: 'wali-aws-dev. wali-aws-dev-md: Minimum availability requires 1 replicas,
      current 0 available. '
    reason: Failed
    status: "False"
    type: Ready
  - lastTransitionTime: "2024-11-19T13:01:08Z"
    message: Credential is Ready
    reason: Succeeded
    status: "True"
    type: CredentialReady
  - lastTransitionTime: "2024-11-19T07:17:13Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: SveltosProfileReady
  - lastTransitionTime: "2024-11-19T07:17:13Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: FetchServicesStatusSuccess
  - lastTransitionTime: "2024-11-19T07:18:57Z"
    message: wali-aws-dev is Ready
    reason: Succeeded
    status: "True"
    type: ControlPlaneInitialized
  - lastTransitionTime: "2024-11-19T13:28:07Z"
    message: wali-aws-dev
    reason: WaitingForControlPlane
    status: "False"
    type: ControlPlaneReady
  - lastTransitionTime: "2024-11-19T07:17:15Z"
    message: wali-aws-dev is Ready
    reason: Succeeded
    status: "True"
    type: InfrastructureReady
  - lastTransitionTime: "2024-11-19T13:18:15Z"
    message: 'wali-aws-dev-md: Minimum availability requires 1 replicas, current 0
      available'
    reason: WaitingForAvailableMachines
    status: "False"
    type: Available
  observedGeneration: 3
  services:
  - clusterName: wali-aws-dev
    clusterNamespace: hmc-system
    conditions:
    - lastTransitionTime: "2024-11-19T07:18:57Z"
      message: ""
      reason: Provisioned
      status: "True"
      type: Helm
    - lastTransitionTime: "2024-11-19T07:18:57Z"
      message: Release kyverno/kyverno
      reason: Managing
      status: "True"
      type: kyverno.kyverno/SveltosHelmReleaseReady
```
Even though the status shows failures, we should still see its child Profile object updated with the new `ingress-nginx` chart (as seen below), which is what we want as described in **"What should be done"** section of [#640](https://github.com/Mirantis/hmc/issues/640):
```yaml
apiVersion: config.projectsveltos.io/v1beta1
kind: Profile
metadata:
  creationTimestamp: "2024-11-19T07:17:13Z"
  finalizers:
  - profilefinalizer.projectsveltos.io
  generation: 3
  labels:
    hmc.mirantis.com/managed: "true"
    projectsveltos.io/cluster-name: wali-aws-dev
    projectsveltos.io/cluster-type: Capi
    projectsveltos.io/profile-name: wali-aws-dev
  name: wali-aws-dev
  namespace: hmc-system
  ownerReferences:
  - apiVersion: hmc.mirantis.com/v1alpha1
    kind: ManagedCluster
    name: wali-aws-dev
    uid: 4039815a-aa24-4677-a054-4f3904a3a023
  resourceVersion: "110917"
  uid: 40da1fef-6381-440d-bc30-bc18edf1c719
spec:
  clusterSelector:
    matchLabels:
      helm.toolkit.fluxcd.io/name: wali-aws-dev
      helm.toolkit.fluxcd.io/namespace: hmc-system
  continueOnConflict: true
  helmCharts:
  - chartName: kyverno
    chartVersion: 3.2.6
    helmChartAction: Install
    registryCredentialsConfig:
      plainHTTP: true
    releaseName: kyverno
    releaseNamespace: kyverno
    repositoryName: kyverno
    repositoryURL: oci://hmc-local-registry:5000/charts
  - chartName: ingress-nginx
    chartVersion: 4.11.3
    helmChartAction: Install
    registryCredentialsConfig:
      plainHTTP: true
    releaseName: ingress-nginx
    releaseNamespace: ingress-nginx
    repositoryName: ingress-nginx
    repositoryURL: oci://hmc-local-registry:5000/charts
  reloader: false
  stopMatchingBehavior: WithdrawPolicies
  syncMode: Continuous
  tier: 2147483547
status:
  matchingClusters:
  - apiVersion: cluster.x-k8s.io/v1beta1
    kind: Cluster
    name: wali-aws-dev
    namespace: hmc-system
```