### PR TITLE
Dev deploy fix - update dev/config aws cluster template version to 0-0-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ spec:
       iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
       instanceType: ""
     workersNumber: 2
-  template: aws-standalone-cp-0-0-2
+  template: aws-standalone-cp-0-0-3
   credential: aws-credential
   dryRun: true
 ```
@@ -235,7 +235,7 @@ metadata:
   name: aws-standalone
   namespace: hmc-system
 spec:
-  template: aws-standalone-cp-0-0-2
+  template: aws-standalone-cp-0-0-3
   credential: aws-credential
   config:
     region: us-east-2

--- a/config/dev/aws-managedcluster.yaml
+++ b/config/dev/aws-managedcluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-dev
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-0-0-2
+  template: aws-standalone-cp-0-0-3
   credential: aws-cluster-identity-cred
   config:
     controlPlane:


### PR DESCRIPTION
## What

`config/dev/aws-managedcluster.yaml` still points to `aws-standalone-cp-0-0-2`, should be `aws-standalone-cp-0-0-3` post merge of #658.

## Why
Right now, I'm getting the following error during a local dev.
```
➜  make dev-mcluster-apply
Error from server (NotFound): error when creating "STDIN": admission webhook "validation.m
anagedcluster.hmc.mirantis.com" denied the request: ClusterTemplate.hmc.mirantis.com "aws-
standalone-cp-0-0-2" not found
make: *** [dev-mcluster-apply] Error 1
```

Fix found through collaboration with @bnallapeta 🙌🏼