### PR TITLE
Fix Airgap bundle creation in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build airgap bundle
         env:
-          IMG: 'ghcr.io/mirantis/hmc:${{ env.VERSION }}'
+          IMG: 'ghcr.io/mirantis/hmc/controller:${{ env.VERSION }}'
         run: |
           make airgap-package
 

--- a/scripts/bundle-images.sh
+++ b/scripts/bundle-images.sh
@@ -131,7 +131,7 @@ fi
 
 echo -e "\nPulling images for HMC components...\n"
 
-for image in $(docker exec -it ${control_plane} crictl images | sed 1,1d | awk '{print $1":"$2}' | grep -v 'kindest');
+for image in $(docker exec ${control_plane} crictl images | sed 1,1d | awk '{print $1":"$2}' | grep -v 'kindest');
 do
     if [[ $image == "" ]]; then
         echo "Error: Failed to get image from KIND cluster, image string should not be empty"


### PR DESCRIPTION
Currently airgap bundle creation fails with:

```
the input device is not a TTY
```
Which prevents to gather list of images and thus providing the bundle with a single image.

The `IMG` variable points to some garbage, fixed as well.