### PR TITLE
Fix - e2e test debug

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
       - opened


### PR DESCRIPTION
This is a temporary measure to allow changes to the github workflow file on PRs so we can figure out why the e2e tests are currently failing. Once those are fixed we will set it back to pull_request_target.