### PR TITLE
Add OpenStack provider support with configuration and templates

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -48,6 +48,8 @@ const (
 	ProviderAzureName = "cluster-api-provider-azure"
 	// Provider vSphere
 	ProviderVSphereName = "cluster-api-provider-vsphere"
+	// Provider OpenStack
+	ProviderOpenStackName = "cluster-api-provider-openstack"
 	// Provider K0smotron
 	ProviderK0smotronName = "k0smotron"
 	// Provider Sveltos

--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -103,6 +103,7 @@ func GetDefaultProviders() []Provider {
 		{Name: ProviderAWSName},
 		{Name: ProviderAzureName},
 		{Name: ProviderVSphereName},
+		{Name: ProviderOpenStackName},
 		{Name: ProviderSveltosName},
 	}
 }

--- a/templates/provider/cluster-api-provider-openstack/.helmignore
+++ b/templates/provider/cluster-api-provider-openstack/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: cluster-api-provider-openstack
+description: A Helm chart for Cluster API provider OpenStack
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.11.3"
+annotations:
+  cluster.x-k8s.io/provider: infrastructure-openstack
+  cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
@@ -1,0 +1,11 @@
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: openstack
+spec:
+  version: v0.11.3
+  {{- if .Values.configSecret.name }}
+  configSecret:
+    name: {{ .Values.configSecret.name }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  {{- end }}

--- a/templates/provider/cluster-api-provider-openstack/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.configSecret.create .Values.configSecret.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.configSecret.name }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+stringData:
+{{ toYaml .Values.config | indent 2 }}
+{{- end }}

--- a/templates/provider/cluster-api-provider-openstack/values.schema.json
+++ b/templates/provider/cluster-api-provider-openstack/values.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Schema for configuration secret settings used in the OpenStack deployment.",
+  "type": "object",
+  "required": [
+    "configSecret"
+  ],
+  "properties": {
+    "configSecret": {
+      "type": "object",
+      "description": "Settings for the OpenStack configuration secret.",
+      "required": [
+        "create",
+        "name"
+      ],
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Indicates whether a new secret should be created."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the OpenStack configuration secret."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace where the OpenStack configuration secret will be created or referenced."
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/templates/provider/cluster-api-provider-openstack/values.yaml
+++ b/templates/provider/cluster-api-provider-openstack/values.yaml
@@ -1,0 +1,6 @@
+configSecret:
+  create: false
+  name: ""
+  namespace: ""
+
+config: {}

--- a/templates/provider/hmc-templates/files/release.yaml
+++ b/templates/provider/hmc-templates/files/release.yaml
@@ -19,5 +19,7 @@ spec:
       template: cluster-api-provider-vsphere-0-0-4
     - name: cluster-api-provider-aws
       template: cluster-api-provider-aws-0-0-4
+    - name: cluster-api-provider-openstack
+      template: cluster-api-provider-openstack-0-0-1
     - name: projectsveltos
       template: projectsveltos-0-44-0

--- a/templates/provider/hmc-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/hmc-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,0 +1,15 @@
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: ProviderTemplate
+metadata:
+  name: cluster-api-provider-openstack-0-0-1
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  helm:
+    chartSpec:
+      chart: cluster-api-provider-openstack
+      version: 0.0.1
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: hmc-templates


### PR DESCRIPTION
Resolves https://github.com/Mirantis/hmc/issues/594.

OpenStack Provider Integration:
- Introduces OpenStack as a supported cloud provider in HMC.
- Adds configurations and provider templates specific to OpenStack environments.


Local Run:

```
ka get machines
NAME                           CLUSTER         NODENAME                       PROVIDERID                                          PHASE     AGE     VERSION
openstack-dev-cp-0             openstack-dev   openstack-dev-cp-0             openstack:///b52ccc71-566b-4487-a0b8-64b2c08f0e5b   Running   8m29s   v1.30.5+k0s.0
openstack-dev-cp-1             openstack-dev   openstack-dev-cp-1             openstack:///4022efcb-da46-4a99-80f3-2eaf3681238e   Running   8m29s   v1.30.5+k0s.0
openstack-dev-cp-2             openstack-dev   openstack-dev-cp-2             openstack:///87ae87e0-2ac5-4f06-b7ba-970d6dbcab3f   Running   8m29s   v1.30.5+k0s.0
openstack-dev-md-p27j6-6wfn4   openstack-dev   openstack-dev-md-p27j6-6wfn4   openstack:///5c2c51c8-f2c0-48d3-9c8f-ed28db53112a   Running   8m30s   
openstack-dev-md-p27j6-w6qvx   openstack-dev   openstack-dev-md-p27j6-w6qvx   openstack:///2df39a6d-2507-452f-9a0a-fb3e6a5d2052   Running   8m30s   
```

```
clusterctl describe cluster openstack-dev -n hmc-system
NAME                                                      READY  SEVERITY  REASON  SINCE  MESSAGE                                                        
Cluster/openstack-dev                                     True                     5m26s                                                                  
├─ClusterInfrastructure - OpenStackCluster/openstack-dev                                                                                                  
├─ControlPlane - K0sControlPlane/openstack-dev-cp                                                                                                         
│ └─3 Machines...                                         True                     7m32s  See openstack-dev-cp-0, openstack-dev-cp-1, ...                 
└─Workers                                                                                                                                                 
  └─MachineDeployment/openstack-dev-md                    True                     110s                                                                   
    └─2 Machines...                                       True                     3m43s  See openstack-dev-md-p27j6-6wfn4, openstack-dev-md-p27j6-w6qvx  
```

```
k -n hmc-system get managedclusters.hmc.mirantis.com 
NAME            READY   STATUS
openstack-dev   True    ManagedCluster is ready
```
