### PR TITLE
Add OpenStack standalone control plane Helm chart and templates

### DIFF
--- a/config/dev/openstack-managedcluster.yaml
+++ b/config/dev/openstack-managedcluster.yaml
@@ -1,0 +1,22 @@
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: ManagedCluster
+metadata:
+  name: openstack-dev
+  namespace: ${NAMESPACE}
+spec:
+  template: openstack-standalone-cp-0-0-1
+  credential: openstack-cluster-identity-cred
+  config:
+    controlPlaneNumber: 1
+    workersNumber: 1
+    controlPlane:
+      flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
+      image:
+        filter:
+          name: ${OPENSTACK_IMAGE_NAME}
+    worker:
+      flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
+      image:
+        filter:
+          name: ${OPENSTACK_IMAGE_NAME}
+    authURL: ${OS_AUTH_URL}

--- a/templates/cluster/openstack-standalone-cp/.helmignore
+++ b/templates/cluster/openstack-standalone-cp/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: openstack-standalone-cp
+description: |
+  An HMC template to deploy a k0s cluster on OpenStack with bootstrapped control plane nodes.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.31.1+k0s.1"
+annotations:
+  cluster.x-k8s.io/provider: infrastructure-openstack, control-plane-k0smotron, bootstrap-k0smotron
+  cluster.x-k8s.io/bootstrap-k0smotron: v1beta1
+  cluster.x-k8s.io/control-plane-k0smotron: v1beta1
+  cluster.x-k8s.io/infrastructure-openstack: v1beta1

--- a/templates/cluster/openstack-standalone-cp/templates/_helpers.tpl
+++ b/templates/cluster/openstack-standalone-cp/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "cluster.name" -}}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "openstackmachinetemplate.controlplane.name" -}}
+    {{- include "cluster.name" . }}-cp-mt
+{{- end }}
+
+{{- define "openstackmachinetemplate.worker.name" -}}
+    {{- include "cluster.name" . }}-worker-mt
+{{- end }}
+
+{{- define "k0scontrolplane.name" -}}
+    {{- include "cluster.name" . }}-cp
+{{- end }}
+
+{{- define "k0sworkerconfigtemplate.name" -}}
+    {{- include "cluster.name" . }}-machine-config
+{{- end }}
+
+{{- define "machinedeployment.name" -}}
+    {{- include "cluster.name" . }}-md
+{{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/cluster.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: {{ include "cluster.name" . }}
+spec:
+  {{- with .Values.clusterNetwork }}
+  clusterNetwork:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: K0sControlPlane
+    name: {{ include "k0scontrolplane.name" .  }}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: OpenStackCluster
+    name: {{ include "cluster.name" . }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,0 +1,80 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: K0sControlPlane
+metadata:
+  name: {{ include "k0scontrolplane.name" . }}
+spec:
+  k0sConfigSpec:
+    args:
+      - --enable-worker
+      - --enable-cloud-provider
+      - --kubelet-extra-args="--cloud-provider=external"
+      - --disable-components=konnectivity-server
+    k0s:
+      apiVersion: k0s.k0sproject.io/v1beta1
+      kind: ClusterConfig
+      metadata:
+        name: k0s
+      spec:
+        api:
+          extraArgs:
+            anonymous-auth: "true"
+        extensions:
+          helm:
+            repositories:
+              - name: openstack
+                url: https://kubernetes.github.io/cloud-provider-openstack/
+            charts: 
+              - name: openstack-ccm
+                chartname: openstack/openstack-cloud-controller-manager
+                version: 2.31.1
+                order: 1
+                namespace: kube-system
+                values: |
+                  secret:
+                    enabled: true
+                    name: openstack-cloud-config
+                    create: false
+                  nodeSelector:
+                    node-role.kubernetes.io/control-plane: "true"
+                  tolerations:
+                    - key: node.cloudprovider.kubernetes.io/uninitialized
+                      value: "true"
+                      effect: NoSchedule
+                    - key: node-role.kubernetes.io/control-plane
+                      effect: NoSchedule
+                    - key: node-role.kubernetes.io/master
+                      effect: NoSchedule
+              - name: openstack-csi
+                chartname: openstack/openstack-cinder-csi
+                version: 2.31.2
+                order: 2
+                namespace: kube-system
+                values: |
+                  storageClass:
+                    enabled: true
+                    delete:
+                      isDefault: false
+                      allowVolumeExpansion: true
+                    retain:
+                      isDefault: false
+                      allowVolumeExpansion: false
+                  secret:
+                    enabled: true
+                    name: openstack-cloud-config
+                    create: false
+                  csi:
+                    plugin:
+                      nodePlugin:
+                        kubeletDir: /var/lib/k0s/kubelet
+        network:
+          provider: calico
+          calico:
+            mode: vxlan
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: OpenStackMachineTemplate
+      name: {{ include "openstackmachinetemplate.controlplane.name" . }}
+      namespace: {{ .Release.Namespace }}
+  replicas: {{ .Values.controlPlaneNumber }}
+  version: {{ .Values.k0s.version }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,0 +1,11 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: K0sWorkerConfigTemplate
+metadata:
+  name: {{ include "k0sworkerconfigtemplate.name" . }}
+spec:
+  template:
+    spec:
+      args:
+      - --enable-cloud-provider
+      - --kubelet-extra-args="--cloud-provider=external"
+      version: {{ .Values.k0s.version }}

--- a/templates/cluster/openstack-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/machinedeployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: {{ include "machinedeployment.name" . }}
+spec:
+  clusterName: {{ include "cluster.name" . }}
+  replicas: {{ .Values.workersNumber }}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: K0sWorkerConfigTemplate
+          name: {{ include "k0sworkerconfigtemplate.name" . }}
+      clusterName: {{ include "cluster.name" . }}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: OpenStackMachineTemplate
+        name: {{ include "openstackmachinetemplate.worker.name" . }}  

--- a/templates/cluster/openstack-standalone-cp/templates/openstackcluster.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackcluster.yaml
@@ -1,0 +1,32 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackCluster
+metadata:
+  name: {{ include "cluster.name" . }}
+spec:
+  {{- if .Values.apiServerLoadBalancer }}
+  apiServerLoadBalancer:
+    {{- toYaml .Values.apiServerLoadBalancer | nindent 4 }}
+  {{- end }}
+  {{- if .Values.bastion.enabled }}
+  bastion:
+  {{- with .Values.bastion.spec }}
+    spec:
+      {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.externalNetwork }}
+  externalNetwork:
+    {{- toYaml .Values.externalNetwork | nindent 4 }}
+  {{- end }}
+  {{- if .Values.identityRef }}
+  identityRef:
+    name: {{ .Values.identityRef.name }}
+    cloudName: {{ .Values.identityRef.cloudName | default "openstack" }}
+    region: {{ .Values.identityRef.region | default "RegionOne" }}
+  {{- end }}
+  managedSecurityGroups:
+    {{- toYaml .Values.managedSecurityGroups | nindent 4 }}
+  {{- if .Values.managedSubnets }}
+  managedSubnets:
+    {{- toYaml .Values.managedSubnets | nindent 4 }}
+  {{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
@@ -1,0 +1,32 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: {{ include "openstackmachinetemplate.controlplane.name" . }}
+spec:
+  template:
+    spec:
+      flavor: {{ .Values.controlplane.flavor }}
+      identityRef:
+        name: {{ .Values.identityRef.name }}
+        region: {{ .Values.identityRef.region }}
+        cloudName: {{ .Values.identityRef.cloudName}}
+      image:
+        filter:
+          name: {{ .Values.controlplane.image.filter.name }}
+          {{- if .Values.controlplane.image.filter.tags }}
+          tags:
+            {{- range $tag := .Values.controlplane.image.filter.tags }}
+            - {{ $tag }}
+            {{- end }}
+          {{- end }}
+      {{- if gt (len .Values.controlplane.portOpts) 0 }}
+      portOpts:
+        {{ .Values.controlplane.portOpts | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if gt (len .Values.controlplane.securityGroups) 0 }}
+      securityGroups:
+        {{ .Values.controlplane.securityGroups | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if not ( .Values.controlplane.sshPublicKey | empty) }}
+      sshKeyName: {{ .Values.controlplane.sshPublicKey }}
+      {{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
@@ -1,0 +1,32 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: {{ include "openstackmachinetemplate.worker.name" . }}
+spec:
+  template:
+    spec:
+      flavor: {{ .Values.worker.flavor }}
+      identityRef:
+        name: {{ .Values.identityRef.name }}
+        region: {{ .Values.identityRef.region }}
+        cloudName: {{ .Values.identityRef.cloudName}}
+      image:
+        filter:
+          name: {{ .Values.worker.image.filter.name }}
+          {{- if .Values.worker.image.filter.tags }}
+          tags:
+            {{- range $tag := .Values.worker.image.filter.tags }}
+            - {{ $tag }}
+            {{- end }}
+          {{- end }}
+      {{- if gt (len .Values.worker.portOpts) 0 }}
+      portOpts:
+        {{ .Values.worker.portOpts | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if gt (len .Values.worker.securityGroups) 0 }}
+      securityGroups:
+        {{ .Values.worker.securityGroups | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if not ( .Values.worker.sshPublicKey | empty) }}
+      sshKeyName: {{ .Values.worker.sshPublicKey }}
+      {{- end }}      

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -1,0 +1,404 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "An HMC template to deploy a k0s cluster on OpenStack with control plane and worker nodes.",
+  "type": "object",
+  "required": [
+    "controlPlaneNumber",
+    "workersNumber",
+    "identityRef",
+    "controlplane",
+    "worker"
+  ],
+  "properties": {
+    "controlPlaneNumber": {
+      "description": "The number of control plane nodes",
+      "type": "number",
+      "minimum": 1
+    },
+    "workersNumber": {
+      "description": "The number of worker nodes",
+      "type": "number",
+      "minimum": 1
+    },
+    "clusterNetwork": {
+      "type": "object",
+      "properties": {
+        "pods": {
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          }
+        },
+        "services": {
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          }
+        },
+        "serviceDomain": {
+          "type": "string",
+          "description": "The service domain for the cluster"
+        }
+      }
+    },
+    "identityRef": {
+      "type": "object",
+      "description": "OpenStack cluster identity object reference",
+      "required": [
+        "name",
+        "cloudName",
+        "region"
+      ],
+      "properties": {
+        "name": {
+          "description": "Cluster identity object name",
+          "type": "string"
+        },
+        "cloudName": {
+          "description": "Name of the entry in the clouds.yaml file to use",
+          "type": "string"
+        }
+      }
+    },
+    "managedSubnets": {
+      "type": "array",
+      "description": "Subnets managed by OpenStack for the cluster",
+      "items": {
+        "type": "object",
+        "properties": {
+          "cidr": {
+            "type": "string",
+            "description": "CIDR block for the subnet"
+          },
+          "dnsNameservers": {
+            "type": "array",
+            "description": "List of DNS nameservers for the subnet",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["cidr"]
+      }
+    },
+    "managedSecurityGroups": {
+      "type": "object",
+      "description": "Defines whether OpenStack security groups are managed by the provider or specific rules are provided",
+      "properties": {
+        "allowAllInClusterTraffic": {
+          "type": "boolean",
+          "description": "Allow all traffic within the cluster security groups"
+        }
+      },
+      "required": ["allowAllInClusterTraffic"]
+    },      
+    "network": {
+      "type": "object",
+      "description": "Networking resources reference for nodes",
+      "required": [
+        "name",
+        "subnets"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the OpenStack network",
+          "type": "string"
+        },
+        "subnets": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "Name of the OpenStack subnet",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "bastion": {
+      "type": "object",
+      "description": "Configuration of the bastion host",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable bastion server for SSH access"
+        },
+        "spec": {
+          "type": "object",
+          "properties": {
+            "providerID": {
+              "type": ["string", "null"],
+              "description": "Provider ID of the bastion server"
+            },
+            "flavor": {
+              "type": ["string", "null"],
+              "description": "Flavor of the bastion server"
+            },
+            "image": {
+              "type": "object",
+              "properties": {
+                "filter": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the image"
+                    },
+                    "tags": {
+                      "type": "object",
+                      "description": "Tags for filtering the image"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "apiServerLoadBalancer": {
+      "type": "object",
+      "description": "Configuration for external load balancer for API server",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable/disable external load balancer for the API server"
+        }
+      }
+    },
+    "externalNetwork": {
+      "type": "object",
+      "description": "External network configuration for the cluster",
+      "properties": {
+        "id": {
+          "type": ["string", "null"],
+          "description": "ID of the external network"
+        },
+        "filter": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the external network"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
+            }
+          }
+        }
+      }
+    },
+    "controlplane": {
+      "type": "object",
+      "description": "Configuration of the control plane instances",
+      "required": [
+        "flavor"
+      ],
+      "properties": {
+        "sshPublicKey": {
+          "type": "string",
+          "description": "SSH public key for accessing nodes"
+        },
+        "providerID": {
+          "type": ["string", "null"],
+          "description": "Unique ID for the instance provider"
+        },
+        "flavor": {
+          "type": "string",
+          "description": "OpenStack flavor for instance size"
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "filter": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the image"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "portOpts": {
+          "type": "array",
+          "description": "Ports to be attached to the server instance",
+          "items": {
+            "type": "string"
+          }
+        },
+          "securityGroups": {
+          "type": "array",
+          "description": "Security groups to be assigned to the instance",
+          "items": {
+            "type": "object",
+            "properties": {
+            "filter": {
+              "type": "object",
+              "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the security group to filter by"
+              },
+              "description": {
+                "type": "string",
+                "description": "Optional: description for filtering"
+              },
+              "projectID": {
+                "type": "string",
+                "description": "Optional: project ID for filtering"
+              }
+              }
+            }
+            }
+          }
+          }
+      }
+    },
+    "worker": {
+      "type": "object",
+      "description": "Configuration of the worker instances",
+      "required": [
+        "flavor"
+      ],
+      "properties": {
+        "sshPublicKey": {
+          "type": "string",
+          "description": "SSH public key for accessing nodes"
+        },
+        "providerID": {
+          "type": ["string", "null"],
+          "description": "Unique ID for the instance provider"
+        },
+        "flavor": {
+          "type": "string",
+          "description": "OpenStack flavor for instance size"
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "filter": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the image"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "portOpts": {
+          "type": "array",
+          "description": "Ports to be attached to the server instance",
+          "items": {
+            "type": "string"
+          }
+        },
+        "securityGroups": {
+          "type": "array",
+          "description": "Security groups to be assigned to the instance",
+          "items": {
+            "type": "object",
+            "properties": {
+            "filter": {
+              "type": "object",
+              "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the security group to filter by"
+              },
+              "description": {
+                "type": "string",
+                "description": "Optional: description for filtering"
+              },
+              "projectID": {
+                "type": "string",
+                "description": "Optional: project ID for filtering"
+              }
+              }
+            }
+            }
+          }
+          }
+      }
+    },
+    "k0smotron": {
+      "type": "object",
+      "description": "K0smotron parameters",
+      "properties": {
+        "service": {
+          "type": "object",
+          "description": "Configuration of a K0smotron service",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Ingress methods for a K0smotron service",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            },
+            "apiPort": {
+              "type": "number",
+              "description": "The Kubernetes API port for a K0smotron service",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "konnectivityPort": {
+              "type": "number",
+              "description": "The Konnectivity server port",
+              "minimum": 1,
+              "maximum": 65535
+            }
+          }
+        }
+      }
+    },
+    "k0s": {
+      "type": "object",
+      "description": "K0s parameters",
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "K0s version to use"
+        }
+      }
+    }
+  }
+}

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -1,0 +1,69 @@
+controlPlaneNumber: 3
+workersNumber: 2
+
+clusterNetwork:
+  pods:
+    cidrBlocks:
+    - "10.244.0.0/16"
+  services:
+    cidrBlocks:
+    - "10.96.0.0/12"
+  serviceDomain: "cluster.local"
+
+identityRef:
+  name: ""
+  cloudName: ""
+  region: ""
+
+bastion:
+  enabled: false
+  spec:
+    providerID: ""
+    flavor: ""
+    image:
+      filter:
+        name: ""
+
+managedSecurityGroups:
+  allowAllInClusterTraffic: false
+
+managedSubnets:
+- cidr: 10.6.0.0/24
+
+apiServerLoadBalancer:
+  enabled: true
+
+externalNetwork:
+  filter:
+    name: ""
+
+controlplane:
+  sshPublicKey: ""
+  providerID: ""
+  flavor: ""
+  image:
+    filter:
+      name: ""
+  portOpts: []
+  securityGroups:
+    - filter:
+        name: "default"
+        description: ""
+        projectID: ""
+
+worker:
+  sshPublicKey: ""
+  providerID: ""
+  flavor: ""
+  image:
+    filter:
+      name: ""
+  portOpts: []
+  securityGroups:
+    - filter:
+        name: "default"
+        description: ""
+        projectID: ""
+
+k0s:
+  version: v1.31.1+k0s.1

--- a/templates/provider/hmc-templates/files/templates/openstack-standalone-cp-0-0-1.yaml
+++ b/templates/provider/hmc-templates/files/templates/openstack-standalone-cp-0-0-1.yaml
@@ -1,0 +1,15 @@
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: openstack-standalone-cp-0-0-1
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  helm:
+    chartSpec:
+      chart: openstack-standalone-cp
+      version: 0.0.1
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: hmc-templates


### PR DESCRIPTION
Resolves #592.

This PR introduces a Helm chart and associated templates to facilitate the deployment of standalone control plane on OpenStack within the Hybrid Multi-Cloud (HMC) platform. 

Local Run:

```
ka get machines
NAME                           CLUSTER         NODENAME                       PROVIDERID                                          PHASE     AGE     VERSION
openstack-dev-cp-0             openstack-dev   openstack-dev-cp-0             openstack:///b52ccc71-566b-4487-a0b8-64b2c08f0e5b   Running   8m29s   v1.30.5+k0s.0
openstack-dev-cp-1             openstack-dev   openstack-dev-cp-1             openstack:///4022efcb-da46-4a99-80f3-2eaf3681238e   Running   8m29s   v1.30.5+k0s.0
openstack-dev-cp-2             openstack-dev   openstack-dev-cp-2             openstack:///87ae87e0-2ac5-4f06-b7ba-970d6dbcab3f   Running   8m29s   v1.30.5+k0s.0
openstack-dev-md-p27j6-6wfn4   openstack-dev   openstack-dev-md-p27j6-6wfn4   openstack:///5c2c51c8-f2c0-48d3-9c8f-ed28db53112a   Running   8m30s   
openstack-dev-md-p27j6-w6qvx   openstack-dev   openstack-dev-md-p27j6-w6qvx   openstack:///2df39a6d-2507-452f-9a0a-fb3e6a5d2052   Running   8m30s   
```

```
clusterctl describe cluster openstack-dev -n hmc-system
NAME                                                      READY  SEVERITY  REASON  SINCE  MESSAGE                                                        
Cluster/openstack-dev                                     True                     5m26s                                                                  
├─ClusterInfrastructure - OpenStackCluster/openstack-dev                                                                                                  
├─ControlPlane - K0sControlPlane/openstack-dev-cp                                                                                                         
│ └─3 Machines...                                         True                     7m32s  See openstack-dev-cp-0, openstack-dev-cp-1, ...                 
└─Workers                                                                                                                                                 
  └─MachineDeployment/openstack-dev-md                    True                     110s                                                                   
    └─2 Machines...                                       True                     3m43s  See openstack-dev-md-p27j6-6wfn4, openstack-dev-md-p27j6-w6qvx  
```

```
k -n hmc-system get managedclusters.hmc.mirantis.com 
NAME            READY   STATUS
openstack-dev   True    ManagedCluster is ready
```