### PR TITLE
Don't collect CAPI manifests for public clouds + gitignore fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ mkdocs
 
 # airgap-push script directories
 hmc-airgap
+
+# Exclude CAPI operator manifests
+templates/provider/*/files
+# But keep hmc-templates
+!templates/provider/hmc-templates/files

--- a/hack/collect-airgap-providers.sh
+++ b/hack/collect-airgap-providers.sh
@@ -23,10 +23,11 @@ set -e
 PROVIDER_LIST_FILE="${LOCALBIN}/providers.yaml"
 REPOSITORIES_FILE="${LOCALBIN}/capi-repositories.yaml"
 DOWNLOAD_LIST_FILE="${LOCALBIN}/download-list"
+EXCLUDED_PROVIDERS='hmc*\|projectsveltos\|cluster-api-provider-aws\|cluster-api-provider-azure'
 
 $CLUSTERCTL config repositories -o yaml > $REPOSITORIES_FILE
 
-for tmpl in $(ls --color=never -1 $PROVIDER_TEMPLATES_DIR | grep -v 'hmc*\|projectsveltos'); do
+for tmpl in $(ls --color=never -1 $PROVIDER_TEMPLATES_DIR | grep -v $EXCLUDED_PROVIDERS); do
     $HELM template ${PROVIDER_TEMPLATES_DIR}/${tmpl} |
 	path="${PROVIDER_TEMPLATES_DIR}/${tmpl}" $YQ 'select(.apiVersion | test("operator.cluster.x-k8s.io.*")) | [{"name": .metadata.name, "version": .spec.version, "kind": .kind, "path": strenv(path)}]';
 done | grep -v '\[\]' > $PROVIDER_LIST_FILE


### PR DESCRIPTION
Related to #709

Quick fix to not block azure provider installation/testing, since proper fix of #709 may take more time.
I removed AWS as well, since it also doesn't make much sense in the airgap environment.
Also I added generated files directories to `gitignore` to avoid dirty state (which could be annoing)