### PR TITLE
Add Azure AKS Cluster Template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,10 @@ dev-vsphere-creds: envsubst
 
 dev-eks-creds: dev-aws-creds
 
+.PHONY: dev-aks-creds
+dev-aks-creds: envsubst
+	@NAMESPACE=$(NAMESPACE) $(ENVSUBST) -no-unset -i config/dev/aks-credentials.yaml | $(KUBECTL) apply -f -
+
 .PHONY: dev-apply ## Apply the development environment by deploying the kind cluster, local registry and the HMC helm chart.
 dev-apply: kind-deploy registry-deploy dev-push dev-deploy dev-templates dev-release
 

--- a/api/v1alpha1/clusterdeployment_types.go
+++ b/api/v1alpha1/clusterdeployment_types.go
@@ -61,6 +61,10 @@ type ClusterDeploymentSpec struct {
 	Template string `json:"template"`
 	// Name reference to the related Credentials object.
 	Credential string `json:"credential,omitempty"`
+	// PropagateCredentials indicates whether credentials should be propagated
+	// for use by CCM (Cloud Controller Manager).
+	// +kubebuilder:default:=true
+	PropagateCredentials bool `json:"propagateCredentials,omitempty"`
 	// Services is a list of services created via ServiceTemplates
 	// that could be installed on the target cluster.
 	Services []ServiceSpec `json:"services,omitempty"`

--- a/config/dev/aks-clusterdeployment.yaml
+++ b/config/dev/aks-clusterdeployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: ClusterDeployment
+metadata:
+  name: azure-aks-dev
+  namespace: ${NAMESPACE}
+spec:
+  template: azure-aks-0-0-1
+  credential: azure-aks-credential
+  propagateCredentials: false
+  config:
+    location: "westus"
+    machinePools:
+      system:
+        count: 1
+        vmSize: Standard_A4_v2
+      user:
+        count: 1
+        vmSize: Standard_A4_v2

--- a/config/dev/aks-credentials.yaml
+++ b/config/dev/aks-credentials.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-aks-credential
+  namespace: ${NAMESPACE}
+stringData:
+  AZURE_CLIENT_ID: "${AZURE_CLIENT_ID}"
+  AZURE_CLIENT_SECRET: "${AZURE_CLIENT_SECRET}"
+  AZURE_SUBSCRIPTION_ID: "${AZURE_SUBSCRIPTION_ID}"
+  AZURE_TENANT_ID: "${AZURE_TENANT_ID}"
+type: Opaque
+---
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: Credential
+metadata:
+  name: azure-aks-credential
+  namespace: ${NAMESPACE}
+spec:
+  description: Azure AKS credentials
+  identityRef:
+    apiVersion: v1
+    kind: Secret
+    name: azure-aks-credential
+    namespace: ${NAMESPACE}

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -354,9 +354,11 @@ func (r *ClusterDeploymentReconciler) updateCluster(ctx context.Context, mc *hmc
 		return ctrl.Result{RequeueAfter: DefaultRequeueInterval}, nil
 	}
 
-	if err := r.reconcileCredentialPropagation(ctx, mc); err != nil {
-		l.Error(err, "failed to reconcile credentials propagation")
-		return ctrl.Result{}, err
+	if mc.Spec.PropagateCredentials {
+		if err := r.reconcileCredentialPropagation(ctx, mc); err != nil {
+			l.Error(err, "failed to reconcile credentials propagation")
+			return ctrl.Result{}, err
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/webhook/clusterdeployment_webhook.go
+++ b/internal/webhook/clusterdeployment_webhook.go
@@ -277,7 +277,8 @@ func isCredMatchTemplate(cred *hmcv1alpha1.Credential, template *hmcv1alpha1.Clu
 				return errMsg(provider)
 			}
 		case "infrastructure-azure":
-			if idtyKind != "AzureClusterIdentity" {
+			if idtyKind != "AzureClusterIdentity" &&
+				idtyKind != "Secret" {
 				return errMsg(provider)
 			}
 		case "infrastructure-vsphere":

--- a/templates/cluster/azure-aks/.helmignore
+++ b/templates/cluster/azure-aks/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/templates/cluster/azure-aks/Chart.yaml
+++ b/templates/cluster/azure-aks/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: azure-aks
+description: |
+  An HMC template to deploy a cluster on AKS.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+annotations:
+  cluster.x-k8s.io/provider: infrastructure-azure
+  cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-aks/templates/_helpers.tpl
+++ b/templates/cluster/azure-aks/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "cluster.name" -}}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "machinepool.system.name" -}}
+    {{- include "cluster.name" . }}-system
+{{- end }}
+
+{{- define "machinepool.user.name" -}}
+    {{- include "cluster.name" . }}-user
+{{- end }}

--- a/templates/cluster/azure-aks/templates/azureasomanagedcluster.yaml
+++ b/templates/cluster/azure-aks/templates/azureasomanagedcluster.yaml
@@ -1,0 +1,19 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: AzureASOManagedCluster
+metadata:
+  name: {{ include "cluster.name" . }}
+spec:
+  resources:
+    - apiVersion: resources.azure.com/v1api20200601
+      kind: ResourceGroup
+      metadata:
+        annotations:
+          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name }}
+          meta.helm.sh/release-name: {{ .Release.Name }}
+          meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+        labels:
+          helm.toolkit.fluxcd.io/name: {{ .Release.Name }}
+          helm.toolkit.fluxcd.io/namespace: {{ .Release.Namespace }}
+        name: {{ include "cluster.name" . }}
+      spec:
+        location: {{ .Values.location }}

--- a/templates/cluster/azure-aks/templates/azureasomanagedcontrolplane.yaml
+++ b/templates/cluster/azure-aks/templates/azureasomanagedcontrolplane.yaml
@@ -1,0 +1,98 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: AzureASOManagedControlPlane
+metadata:
+  name: {{ include "cluster.name" . }}
+spec:
+  resources:
+    - apiVersion: containerservice.azure.com/v1api20231001
+      kind: ManagedCluster
+      metadata:
+        annotations:
+          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name }}
+          meta.helm.sh/release-name: {{ .Release.Name }}
+          meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+        labels:
+          helm.toolkit.fluxcd.io/name: {{ .Release.Name }}
+          helm.toolkit.fluxcd.io/namespace: {{ .Release.Namespace }}
+        name: {{ include "cluster.name" . }}
+      spec:
+        apiServerAccessProfile:
+          authorizedIPRanges: {{ .Values.apiServerAccessProfile.authorizedIPRanges }}
+          disableRunCommand: {{ .Values.apiServerAccessProfile.disableRunCommand }}
+          {{- if .Values.apiServerAccessProfile.enablePrivateCluster }}
+          enablePrivateCluster: {{ .Values.apiServerAccessProfile.enablePrivateCluster }}
+          enablePrivateClusterPublicFQDN: {{ .Values.apiServerAccessProfile.enablePrivateClusterPublicFQDN }}
+          privateDNSZone: {{ .Values.apiServerAccessProfile.privateDNSZone }}
+          {{- end }}
+        {{- with .Values.autoUpgradeProfile }}
+        autoUpgradeProfile:
+           {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.azureMonitorProfile }}
+        azureMonitorProfile:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        dnsPrefix: {{ include "cluster.name" . }}
+        identity:
+          type: SystemAssigned
+        location: {{ .Values.location }}
+        networkProfile:
+          dnsServiceIP: {{ .Values.dnsServiceIP }}
+          networkPlugin: {{ .Values.kubernetes.networkPlugin }}
+          networkPolicy: {{ .Values.kubernetes.networkPolicy }}
+        oidcIssuerProfile:
+          enabled: {{ .Values.oidcIssuerProfile.enabled }}
+        owner:
+          name: {{ include "cluster.name" . }}
+        securityProfile:
+          {{- if .Values.securityProfile.azureKeyVaultKms.enabled }}
+          azureKeyVaultKms:
+            enabled: {{ .Values.securityProfile.azureKeyVaultKms.enabled }}
+            keyId: {{ .Values.securityProfile.azureKeyVaultKms.keyId }}
+            keyVaultNetworkAccess: {{ .Values.securityProfile.azureKeyVaultKms.keyVaultNetworkAccess }}
+            {{- with .Values.securityProfile.azureKeyVaultKms.keyVaultResourceReference }}
+            keyVaultResourceReference:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+          {{- end }}
+          defender:
+            {{- with .Values.securityProfile.defender.logAnalyticsWorkspaceResourceReference }}
+            logAnalyticsWorkspaceResourceReference:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            securityMonitoring:
+              enabled: {{ .Values.securityProfile.defender.securityMonitoring.enabled }}
+          imageCleaner:
+            enabled: {{ .Values.securityProfile.imageCleaner.enabled }}
+            intervalHours: {{ .Values.securityProfile.imageCleaner.intervalHours }}
+          workloadIdentity:
+            enabled: {{ .Values.securityProfile.workloadIdentity.enabled }}
+        serviceMeshProfile:
+          mode: {{ .Values.serviceMeshProfile.mode }}
+          {{- if eq .Values.serviceMeshProfile.mode "Istio" }}
+          istio:
+            certificateAuthority:
+              certChainObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.certChainObjectName }}
+              certObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.certObjectName }}
+              keyObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.keyObjectName }}
+              {{- with .Values.serviceMeshProfile.istio.certificateAuthority.keyVaultReference }}
+              keyVaultReference:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              rootCertObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.rootCertObjectName }}
+            {{- with .Values.serviceMeshProfile.istio.components }}
+            components:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.serviceMeshProfile.istio.revisions }}
+            revisions:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+        {{- end }}
+        servicePrincipalProfile:
+          clientId: msi
+        {{- with .Values.sku }}
+        sku:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+  version: {{ .Values.kubernetes.version }}

--- a/templates/cluster/azure-aks/templates/azureasomanagedmachinepool-controlplane.yaml
+++ b/templates/cluster/azure-aks/templates/azureasomanagedmachinepool-controlplane.yaml
@@ -1,0 +1,40 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: AzureASOManagedMachinePool
+metadata:
+  name: {{ include "machinepool.system.name" . }}
+spec:
+  resources:
+    - apiVersion: containerservice.azure.com/v1api20231001
+      kind: ManagedClustersAgentPool
+      metadata:
+        annotations:
+          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name }}
+          meta.helm.sh/release-name: {{ .Release.Name }}
+          meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+        labels:
+          helm.toolkit.fluxcd.io/name: {{ .Release.Name }}
+          helm.toolkit.fluxcd.io/namespace: {{ .Release.Namespace }}
+        name: {{ include "machinepool.system.name" . }}
+      spec:
+        azureName: systempool
+        {{- if .Values.machinePools.system.autoscaling.enabled }}
+        enableAutoScaling: {{ .Values.machinePools.system.autoscaling.enabled }}
+        maxCount: {{ .Values.machinePools.system.autoscaling.maxCount }}
+        minCount: {{ .Values.machinePools.system.autoscaling.minCount }}
+        {{- end }}
+        enableNodePublicIP: {{ .Values.machinePools.system.enableNodePublicIP }}
+        maxPods: {{ .Values.machinePools.system.maxPods }}
+        mode: System
+        {{- with .Values.machinePools.system.nodeLabels }}
+        nodeLabels:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.machinePools.system.nodeTaints }}
+        nodeTaints:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        osDiskSizeGB: {{ .Values.machinePools.system.osDiskSizeGB }}
+        owner:
+          name: {{ include "cluster.name" . }}
+        type: {{ .Values.machinePools.system.type }}
+        vmSize: {{ .Values.machinePools.system.vmSize }}

--- a/templates/cluster/azure-aks/templates/azureasomanagedmachinepool-worker.yaml
+++ b/templates/cluster/azure-aks/templates/azureasomanagedmachinepool-worker.yaml
@@ -1,0 +1,41 @@
+
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: AzureASOManagedMachinePool
+metadata:
+  name: {{ include "machinepool.user.name" . }}
+spec:
+  resources:
+    - apiVersion: containerservice.azure.com/v1api20231001
+      kind: ManagedClustersAgentPool
+      metadata:
+        annotations:
+          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name }}
+          meta.helm.sh/release-name: {{ .Release.Name }}
+          meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+        labels:
+          helm.toolkit.fluxcd.io/name: {{ .Release.Name }}
+          helm.toolkit.fluxcd.io/namespace: {{ .Release.Namespace }}
+        name: {{ include "machinepool.user.name" . }}
+      spec:
+        azureName: userpool
+        {{- if .Values.machinePools.user.autoscaling.enabled }}
+        enableAutoScaling: {{ .Values.machinePools.user.autoscaling.enabled }}
+        maxCount: {{ .Values.machinePools.user.autoscaling.maxCount }}
+        minCount: {{ .Values.machinePools.user.autoscaling.minCount }}
+        {{- end }}
+        enableNodePublicIP: {{ .Values.machinePools.user.enableNodePublicIP }}
+        maxPods: {{ .Values.machinePools.user.maxPods }}
+        mode: User
+        {{- with .Values.machinePools.user.nodeLabels }}
+        nodeLabels:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.machinePools.user.nodeTaints }}
+        nodeTaints:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        osDiskSizeGB: {{ .Values.machinePools.user.osDiskSizeGB }}
+        owner:
+          name: {{ include "cluster.name" . }}
+        type: {{ .Values.machinePools.user.type }}
+        vmSize: {{ .Values.machinePools.user.vmSize }}

--- a/templates/cluster/azure-aks/templates/cluster.yaml
+++ b/templates/cluster/azure-aks/templates/cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: {{ include "cluster.name" . }}
+spec:
+  {{- with .Values.clusterNetwork }}
+  clusterNetwork:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  controlPlaneRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: AzureASOManagedControlPlane
+    name: {{ include "cluster.name" .  }}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: AzureASOManagedCluster
+    name: {{ include "cluster.name" . }}

--- a/templates/cluster/azure-aks/templates/machinepool-controlplane.yaml
+++ b/templates/cluster/azure-aks/templates/machinepool-controlplane.yaml
@@ -1,0 +1,17 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: {{ include "machinepool.system.name" . }}
+spec:
+  clusterName: {{ include "cluster.name" . }}
+  replicas: {{ .Values.machinePools.system.count }}
+  template:
+    spec:
+      bootstrap:
+        dataSecretName: {{ include "machinepool.system.name" . }}
+      clusterName: {{ include "cluster.name" . }}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        kind: AzureASOManagedMachinePool
+        name: {{ include "machinepool.system.name" . }}
+      version: {{ .Values.kubernetes.version }}

--- a/templates/cluster/azure-aks/templates/machinepool-worker.yaml
+++ b/templates/cluster/azure-aks/templates/machinepool-worker.yaml
@@ -1,0 +1,17 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: {{ include "machinepool.user.name" . }}
+spec:
+  clusterName: {{ include "cluster.name" . }}
+  replicas: {{ .Values.machinePools.user.count }}
+  template:
+    spec:
+      bootstrap:
+        dataSecretName: {{ include "machinepool.user.name" . }}
+      clusterName: {{ include "cluster.name" . }}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        kind: AzureASOManagedMachinePool
+        name: {{ include "machinepool.user.name" . }}
+      version: {{ .Values.kubernetes.version }}

--- a/templates/cluster/azure-aks/values.schema.json
+++ b/templates/cluster/azure-aks/values.schema.json
@@ -1,0 +1,514 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "An HMC template to deploy a cluster on AKS.",
+  "type": "object",
+  "required": [
+    "clusterIdentity",
+    "location"
+  ],
+  "properties": {
+    "clusterNetwork": {
+      "type": "object",
+      "properties": {
+        "pods": {
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          }
+        },
+        "services": {
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          }
+        }
+      }
+    },
+    "clusterIdentity": {
+      "type": "object",
+      "description": "The reference to the secret containing Azure AKS credentials",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "The name to the secret containing Azure AKS credentials",
+          "type": "string"
+        }
+      }
+    },
+    "apiServerAccessProfile": {
+      "type": "object",
+      "description": "The access profile for managed cluster API server",
+      "properties": {
+        "authorizedIPRanges": {
+          "description": "IP ranges in CIDR format, e.g. 137.117.106.88⁄29",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "disableRunCommand": {
+          "description": "Whether to disable run command for the cluster or not",
+          "type": "boolean"
+        },
+        "enablePrivateCluster": {
+          "description": "Whether to enable private cluster or not",
+          "type": "boolean"
+        },
+        "enablePrivateClusterPublicFQDN": {
+          "description": "Whether to create additional public FQDN for private cluster or not",
+          "type": "boolean"
+        },
+        "privateDNSZone": {
+          "description": "Private DNS zone. The default is: system",
+          "enum": ["system", "none"],
+          "type": "string"
+        }
+      }
+    },
+    "autoUpgradeProfile": {
+      "type": "object",
+      "description": "Auto upgrade profile for a managed cluster",
+      "properties": {
+        "nodeOSUpgradeChannel": {
+          "description": "Manner in which the OS on your nodes is updated",
+          "enum": ["NodeImage", "None", "Unmanaged"],
+          "type": "string"
+        },
+        "upgradeChannel": {
+          "description": "Upgrade channel",
+          "enum": ["node-image","none","patch","rapid","stable"],
+          "type": "string"
+        }
+      }
+    },
+    "azureMonitorProfile": {
+      "type": "object",
+      "description": "Azure Monitor addon profiles for monitoring the managed cluster",
+      "properties": {
+        "metrics": {
+          "description": "Metrics profile for the Azure Monitor managed service for Prometheus addon",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring",
+              "type": "boolean"
+            },
+            "kubeStateMetrics": {
+              "description": "Kube State Metrics profile for the Azure Managed Prometheus addon",
+              "type": "object",
+              "properties": {
+                "metricAnnotationsAllowList": {
+                  "description": "Comma-separated list of Kubernetes annotation keys that will be used in the resource’s labels metric (Example: ‘namespaces=[kubernetes.io/team,…],pods=[kubernetes.io/team],…’)",
+                  "type": "string"
+                },
+                "metricLabelsAllowlist": {
+                  "description": "Comma-separated list of additional Kubernetes label keys that will be used in the resource’s labels metric (Example: ‘namespaces=[k8s-label-1,k8s-label-n,…],pods=[app],…’)",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "dnsServiceIP": {
+      "description": "An IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr",
+      "type": "string"
+    },
+    "location": {
+      "description": "Azure location to deploy the cluster in",
+      "type": "string"
+    },
+    "oidcIssuerProfile": {
+      "type": "object",
+      "description": "The OIDC issuer profile of the Managed Cluster",
+      "properties": {
+        "enabled": {
+          "description": "Whether the OIDC issuer is enabled",
+          "type": "boolean"
+        }
+      }
+    },
+    "securityProfile": {
+      "type": "object",
+      "description": "Security profile for the managed cluster",
+      "properties": {
+        "azureKeyVaultKms": {
+          "description": "Azure Key Vault key management service settings for the security profile",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Whether to enable Azure Key Vault key management service",
+              "type": "boolean"
+            },
+            "keyId": {
+              "description": "Identifier of Azure Key Vault key",
+              "type": "string"
+            },
+            "keyVaultNetworkAccess": {
+              "description": "Network access of key vault. The possible values are Public and Private",
+              "enum": ["Public","Private"],
+              "type": "string"
+            },
+            "keyVaultResourceReference": {
+              "description": "Resource ID of key vault. When keyVaultNetworkAccess is Private, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is Public, leave the field empty",
+              "type": "object",
+              "properties": {
+                "armId": {
+                  "description": "A string of the form /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName} with the resource reference",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "defender": {
+          "description": "Microsoft Defender settings for the security profile",
+          "type": "object",
+          "properties": {
+            "logAnalyticsWorkspaceResourceReference": {
+              "description": "Resource ID of the Log Analytics workspace to be associated with Microsoft Defender",
+              "type": "object",
+              "properties": {
+                "armId": {
+                  "description": "A string of the form /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName} with the resource reference",
+                  "type": "string"
+                }
+              }
+            },
+            "securityMonitoring": {
+              "description": "Microsoft Defender threat detection for Cloud settings for the security profile",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Whether to enable Defender threat detection",
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "imageCleaner": {
+          "description": "Image Cleaner settings for the security profile",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Whether to enable Image Cleaner on AKS cluster",
+              "type": "boolean"
+            },
+            "intervalHours": {
+              "description": "Image Cleaner scanning interval in hours",
+              "type": "integer"
+            }
+          }
+        },
+        "workloadIdentity": {
+          "description": "Workload identity settings for the security profile",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Whether to enable workload identity",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "serviceMeshProfile": {
+      "description": "Service mesh profile for a managed cluster",
+      "type": "object",
+      "properties": {
+        "mode": {
+          "description": "Mode of the service mesh",
+          "enum": ["Disabled","Istio"],
+          "type": "string"
+        },
+        "istio": {
+          "description": "Istio service mesh configuration",
+          "type": "object",
+          "properties": {
+            "certificateAuthority": {
+              "description": "Istio Service Mesh Certificate Authority (CA) configuration",
+              "type": "object",
+              "properties": {
+                "certChainObjectName": {
+                  "description": "Certificate chain object name in Azure Key Vault",
+                  "type": "string"
+                },
+                "certObjectName": {
+                  "description": "Intermediate certificate object name in Azure Key Vault",
+                  "type": "string"
+                },
+                "keyObjectName": {
+                  "description": "Intermediate certificate private key object name in Azure Key Vault",
+                  "type": "string"
+                },
+                "keyVaultReference": {
+                  "description": "The resource ID of the Key Vault",
+                  "type": "object",
+                  "properties": {
+                    "armId": {
+                      "description": "A string of the form /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName} with the resource reference",
+                      "type": "string"
+                    }
+                  }
+                },
+                "rootCertObjectName": {
+                  "description": "Root certificate object name in Azure Key Vault",
+                  "type": "string"
+                }
+              }
+            },
+            "components": {
+              "description": "Istio components configuration",
+              "type": "object",
+              "properties": {
+                "egressGateways": {
+                  "description": "Istio egress gateways",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "description": "Whether to enable the egress gateway",
+                        "type": "boolean"
+                      },
+                      "nodeSelector": {
+                        "description": "NodeSelector for scheduling the egress gateway. Format: map[string]string",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ingressGateways": {
+                  "description": "Istio ingress gateways",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "description": "Whether to enable the ingress gateway",
+                        "type": "boolean"
+                      },
+                      "mode": {
+                        "description": "Mode of an ingress gateway. Supported values: Internal, External",
+                        "enum": ["Internal","External"],
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "revisions": {
+              "description": "The list of revisions of the Istio control plane",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
+            }
+          }
+        }
+      }
+    },
+    "sku": {
+      "description": "The SKU of a Managed Cluster",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of a managed cluster SKU",
+          "type": "string"
+        },
+        "tier": {
+          "description": "AKS pricing tier. Default: Free",
+          "enum": ["Free", "Premium", "Standard"],
+          "type": "string"
+        }
+      }
+    },
+    "machinePools": {
+      "description": "The machine pools' configuration",
+      "type": "object",
+      "properties": {
+        "system": {
+          "description": "The configuration of the system machine pool",
+          "type": "object",
+          "required": [
+            "vmSize"
+          ],
+          "properties": {
+            "autoscaling": {
+              "description": "Machine Pool autoscaling options",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Whether to enable auto-scaler or not",
+                  "type": "boolean"
+                },
+                "minCount": {
+                  "description": "The minimum number of nodes for auto-scaling",
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "maxCount": {
+                  "description": "The maximum number of nodes for auto-scaling",
+                  "type": "integer"
+                }
+              }
+            },
+            "count": {
+              "description": "Number of VMs to host docker containers",
+              "type": "integer",
+              "minimum": 1
+            },
+            "enableNodePublicIP": {
+              "description": "Whether to enable node public IP or not",
+              "type": "boolean"
+            },
+            "maxPods": {
+              "description": "The maximum number of pods that can run on a node",
+              "type": "integer"
+            },
+            "nodeLabels": {
+              "description": "The node labels to be persisted across all nodes in agent pool",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "nodeTaints": {
+              "description": "The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "osDiskSizeGB": {
+              "description": "The size of OS Disk in GB",
+              "type": "integer"
+            },
+            "type": {
+              "description": "The type of Agent Pool",
+              "enum": ["AvailabilitySet","VirtualMachineScaleSets"],
+              "type": "string"
+            },
+            "vmSize": {
+              "description": "The size of a VM",
+              "type": "string"
+            }
+          }
+        },
+        "user": {
+          "description": "The configuration of the user machine pool",
+          "type": "object",
+          "required": [
+            "vmSize"
+          ],
+          "properties": {
+            "autoscaling": {
+              "description": "Machine Pool autoscaling options",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Whether to enable auto-scaler or not",
+                  "type": "boolean"
+                },
+                "minCount": {
+                  "description": "The minimum number of nodes for auto-scaling",
+                  "type": "integer"
+                },
+                "maxCount": {
+                  "description": "The maximum number of nodes for auto-scaling",
+                  "type": "integer"
+                }
+              }
+            },
+            "count": {
+              "description": "Number of VMs to host docker containers",
+              "type": "integer"
+            },
+            "enableNodePublicIP": {
+              "description": "Whether to enable node public IP or not",
+              "type": "boolean"
+            },
+            "maxPods": {
+              "description": "The maximum number of pods that can run on a node",
+              "type": "integer"
+            },
+            "nodeLabels": {
+              "description": "The node labels to be persisted across all nodes in agent pool",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "nodeTaints": {
+              "description": "The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "osDiskSizeGB": {
+              "description": "The size of OS Disk in GB",
+              "type": "integer"
+            },
+            "type": {
+              "description": "The type of Agent Pool",
+              "enum": ["AvailabilitySet","VirtualMachineScaleSets"],
+              "type": "string"
+            },
+            "vmSize": {
+              "description": "The size of a VM",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "kubernetes": {
+      "description": "Kubernetes parameters",
+      "type": "object",
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "networkPolicy": {
+          "description": "Network policy used for building the Kubernetes network. Defaults to: azure",
+          "type": "string",
+          "enum": ["azure", "calico", "cilium"]
+        },
+        "networkPlugin": {
+          "description": "Network plugin used for building the Kubernetes network. Defaults to: azure",
+          "type": "string",
+          "enum": ["azure", "kubenet", "none"]
+        },
+        "version":{
+          "description": "Kubernetes version to use",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/templates/cluster/azure-aks/values.yaml
+++ b/templates/cluster/azure-aks/values.yaml
@@ -1,0 +1,106 @@
+# Cluster parameters
+clusterNetwork:
+  pods:
+    cidrBlocks:
+    - "10.244.0.0/16"
+  services:
+    cidrBlocks:
+    - "10.96.0.0/12"
+
+clusterIdentity:
+  name: ""
+
+# AKS cluster parameters
+apiServerAccessProfile:
+  authorizedIPRanges: []
+  disableRunCommand: false
+  enablePrivateCluster: false
+  enablePrivateClusterPublicFQDN: false
+  privateDNSZone: system
+
+autoUpgradeProfile:
+  nodeOSUpgradeChannel: "None"
+  upgradeChannel: "none"
+
+azureMonitorProfile:
+  metrics:
+    enabled: false
+    kubeStateMetrics:
+      metricAnnotationsAllowList: ""
+      metricLabelsAllowlist: ""
+
+dnsServiceIP: 10.96.0.10
+
+location: ""
+
+oidcIssuerProfile:
+  enabled: false
+
+securityProfile:
+  azureKeyVaultKms:
+    enabled: false
+    keyId: ""
+    keyVaultNetworkAccess: "Public"
+    keyVaultResourceReference: {}
+  defender:
+    logAnalyticsWorkspaceResourceReference: {}
+    securityMonitoring:
+      enabled: false
+  imageCleaner:
+    enabled: false
+    intervalHours: 1
+  workloadIdentity:
+    enabled: false
+
+serviceMeshProfile:
+  mode: Disabled
+  istio:
+    certificateAuthority:
+      certChainObjectName: ""
+      certObjectName: ""
+      keyObjectName: ""
+      keyVaultReference: {}
+      rootCertObjectName: ""
+    components:
+      egressGateways: []
+      ingressGateways: []
+    revisions: []
+
+sku:
+  name: Base
+  tier: Free
+
+# AKS System and User MachinePool parameters
+machinePools:
+  system:
+    autoscaling:
+      enabled: false
+      minCount: 2
+      maxCount: 5
+    count: 3
+    enableNodePublicIP: false
+    maxPods: 110
+    nodeLabels: {}
+    nodeTaints: []
+    osDiskSizeGB: 128
+    type: VirtualMachineScaleSets
+    vmSize: ""
+  user:
+    autoscaling:
+      enabled: false
+      minCount: 2
+      maxCount: 5
+    count: 2
+    enableNodePublicIP: false
+    maxPods: 110
+    nodeLabels: {}
+    nodeTaints: []
+    osDiskSizeGB: 128
+    type: VirtualMachineScaleSets
+    vmSize: ""
+
+# Kubernetes parameters
+kubernetes:
+  networkPolicy: azure
+  networkPlugin: azure
+  version: v1.31.1

--- a/templates/provider/hmc-templates/files/templates/azure-aks-0-0-1.yaml
+++ b/templates/provider/hmc-templates/files/templates/azure-aks-0-0-1.yaml
@@ -1,0 +1,15 @@
+apiVersion: hmc.mirantis.com/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: azure-aks-0-0-1
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  helm:
+    chartSpec:
+      chart: azure-aks
+      version: 0.0.1
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: hmc-templates

--- a/templates/provider/hmc/templates/crds/hmc.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/hmc/templates/crds/hmc.mirantis.com_clusterdeployments.yaml
@@ -69,6 +69,12 @@ spec:
                 description: DryRun specifies whether the template should be applied
                   after validation or only validated.
                 type: boolean
+              propagateCredentials:
+                default: true
+                description: |-
+                  PropagateCredentials indicates whether credentials should be propagated
+                  for use by CCM (Cloud Controller Manager).
+                type: boolean
               services:
                 description: |-
                   Services is a list of services created via ServiceTemplates


### PR DESCRIPTION
This PR introduces the following changes:
1. A new template for `azure-aks` clusters has been added.
2. The ClusterDeployment spec now supports the option to skip propagating credentials by setting `propagateCredentials: false`. This is particularly needed for AKS clusters, as they do not require credential propagation.
3. Added YAMLs with AKS credentials and managed cluster.

There are two API options for creating AKS clusters: `ManagedCluster` and `ASOManagedCluster`. The `ASOManagedCluster` approach was chosen because the `ManagedCluster` will eventually be deprecated. See [CAPZ ManagedCluster vs. ASOManagedCluster](https://capz.sigs.k8s.io/managed/managed#capzs-managed-cluster-versus-capzs-asomanaged-cluster).

### ASO Credentials
ASO (azure service operator) requires Azure credentials to be defined in a Kubernetes Secret and does not support reading creds from `AzureClusterIdentity` (source: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/proposals/20230123-azure-service-operator.md#security-model).

Closes #744 