### PR TITLE
Fetch only commit sha from GET PR

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -30,22 +30,22 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.version }}
       clustername: ${{ steps.vars.outputs.clustername }}
-      pr: ${{ steps.pr.outputs.result }}
+      merge_commit_sha: ${{ steps.merge_commit_sha.outputs.result }}
     steps:
-      - name: Get PR ref
+      - name: Get PR Commit SHA
         uses: actions/github-script@v7
-        id: pr
+        id: merge_commit_sha
         with:
           script: |
             const { data: pullRequest } = await github.rest.pulls.get({
               ...context.repo,
               pull_number: context.payload.pull_request.number,
             });
-            return pullRequest
+            return pullRequest.merge_commit_sha
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{fromJSON(steps.pr.outputs.result).merge_commit_sha}}
+          ref: ${{steps.merge_commit_sha.outputs.result}}
           fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -100,13 +100,13 @@ jobs:
     outputs:
       clustername: ${{ needs.build.outputs.clustername }}
       version: ${{ needs.build.outputs.version }}
-      pr: ${{ needs.build.outputs.pr }}
+      merge_commit_sha: ${{ needs.build.outputs.merge_commit_sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
+          ref: ${{ needs.build.outputs.merge_commit_sha }}
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
       - name: Run E2E tests
@@ -136,7 +136,7 @@ jobs:
     outputs:
       clustername: ${{ needs.build.outputs.clustername }}
       version: ${{ needs.build.outputs.version }}
-      pr: ${{ needs.build.outputs.pr }}
+      merge_commit_sha: ${{ needs.build.outputs.merge_commit_sha }}
     env:
       AWS_REGION: us-west-2
       AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
@@ -151,7 +151,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
+          ref: ${{ needs.build.outputs.merge_commit_sha }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -186,7 +186,7 @@ jobs:
     outputs:
       clustername: ${{ needs.build.outputs.clustername }}
       version: ${{ needs.build.outputs.version }}
-      pr: ${{ needs.build.outputs.pr }}
+      merge_commit_sha: ${{ needs.build.outputs.merge_commit_sha }}
     env:
       VSPHERE_USER: ${{ secrets.CI_VSPHERE_USER }}
       VSPHERE_PASSWORD: ${{ secrets.CI_VSPHERE_PASSWORD }}
@@ -205,7 +205,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
+          ref: ${{ needs.build.outputs.merge_commit_sha }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -239,13 +239,13 @@ jobs:
     outputs:
       clustername: ${{ needs.build.outputs.clustername }}
       version: ${{ needs.build.outputs.version }}
-      pr: ${{ needs.build.outputs.pr }}
+      merge_commit_sha: ${{ needs.build.outputs.merge_commit_sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
+          ref: ${{ needs.build.outputs.merge_commit_sha }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
The change will take place only after it is merged. Since the initial bug is not reproducible, the PR is optional to be merged (and can be closed)

Fixes #820 (which is already not reproducible)