### PR TITLE
Update ManagedCluster to ClusterDeployment for OpenStack dev file

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: hmc.mirantis.com/v1alpha1
-kind: ManagedCluster
+kind: ClusterDeployment
 metadata:
   name: openstack-dev
   namespace: ${NAMESPACE}


### PR DESCRIPTION
With the recent change in name for `ManagedCluster`, the files under config/dev was not updated with the latest `ClusterDeployment` name. This PR fixes it.